### PR TITLE
Security: Add integrity verification for downloaded installers

### DIFF
--- a/AppConfig.ps1
+++ b/AppConfig.ps1
@@ -24,6 +24,7 @@ $script:AppConfigurations = @{
         DetectionFile = "firefox.exe"
         DetectionType = "File"
         DetectionOperator = "greaterThanOrEqual"
+        ExpectedPublisher = "Mozilla Corporation"
         AutoUpdate = $true
     }
     
@@ -45,6 +46,7 @@ $script:AppConfigurations = @{
         DetectionFile = "chrome.exe"
         DetectionOperator = "greaterThanOrEqual"
         VersionExtraction = "AppLocker"  # Extract version after download using Get-AppLockerFileInformation
+        ExpectedPublisher = "Google LLC"
         AutoUpdate = $true
     }
     
@@ -68,6 +70,7 @@ $script:AppConfigurations = @{
         DetectionType = "MSI"
         DetectionOperator = "ProductCodeOnly"  # Simple product code detection, no version operator needed
         VersionFormat = "NoPrefix"  # Version like "7z2501" needs special handling
+        AllowUnsignedInstaller = $true  # 7-Zip MSI is not Authenticode-signed
         AutoUpdate = $true
     }
     
@@ -92,6 +95,7 @@ $script:AppConfigurations = @{
         DetectionFile = "gimp-3.0.exe"
         DetectionType = "File"
         DetectionOperator = "equal"
+        ExpectedPublisher = "Jernej"
         AutoUpdate = $true
     }
     
@@ -116,6 +120,7 @@ $script:AppConfigurations = @{
         DetectionFile = "vlc.exe"
         DetectionType = "File"
         DetectionOperator = "equal"
+        AllowUnsignedInstaller = $true  # VLC EXE signature status is unreliable across versions
         AutoUpdate = $true
     }
     
@@ -140,6 +145,7 @@ $script:AppConfigurations = @{
         DetectionFile = "notepad++.exe"
         DetectionType = "File"
         DetectionOperator = "equal"
+        ExpectedPublisher = "NOTEPAD++"
         AutoUpdate = $true
     }
     
@@ -161,6 +167,7 @@ $script:AppConfigurations = @{
         VersionExtraction = "AppLocker"  # Extract version after download using Get-AppLockerFileInformation
         ManualExtraction = $true  # Requires manual extraction: Run downloaded EXE with /extract /defaults
         ExtractionCommand = '"{0}" /extract /defaults'  # Command to extract MSI from EXE
+        ExpectedPublisher = "Canva"  # Affinity is now owned by Canva; signature check runs on EXE before extraction
         AutoUpdate = $true
     }
     
@@ -184,6 +191,7 @@ $script:AppConfigurations = @{
         UninstallCommandTemplate = 'msiexec /x {0} /qn'  # {0} will be MSI product code
         DetectionType = "MSI"
         DetectionOperator = "ProductCodeOnly"
+        AllowUnsignedInstaller = $true  # Inkscape MSI has unreliable signature (self-signed/incomplete cert chain)
         AutoUpdate = $true
     }
     
@@ -208,6 +216,7 @@ $script:AppConfigurations = @{
         DetectionFile = "Audacity.exe"
         DetectionType = "File"
         DetectionOperator = "greaterThanOrEqual"
+        ExpectedPublisher = "MuseCY"
         AutoUpdate = $true
     }
     
@@ -230,6 +239,7 @@ $script:AppConfigurations = @{
         UninstallCommandTemplate = 'msiexec /x {0} /qn'  # {0} will be MSI product code
         DetectionType = "MSI"
         DetectionOperator = "ProductCodeOnly"
+        ExpectedPublisher = "Document Foundation"
         AutoUpdate = $true
     }
     
@@ -254,6 +264,7 @@ $script:AppConfigurations = @{
         DetectionFile = "OpenShot Video Editor.exe"
         DetectionType = "File"
         DetectionOperator = "greaterThanOrEqual"
+        ExpectedPublisher = "OpenShot Studios"
         AutoUpdate = $true
     }
     
@@ -276,6 +287,7 @@ $script:AppConfigurations = @{
         DetectionScriptPath = "packages\geogebra\Detect-GeoGebraVersion.ps1"  # Custom script to extract version from HTML files
         VersionExtraction = "AppLocker"  # Extract version after download using Get-AppLockerFileInformation
         SupersedenceType = "Replace"  # Use Replace instead of Update (uninstalls old version)
+        ExpectedPublisher = "GeoGebra GmbH"
         AutoUpdate = $true
         # Note: GeoGebra doesn't update MSI Product Code or GeoGebra.exe version between releases
         # Real version is stored in latestVersion variable in HTML files (main.js or ggb-config.js)
@@ -302,6 +314,7 @@ $script:AppConfigurations = @{
         DetectionFile = "stellarium.exe"
         DetectionType = "File"
         DetectionOperator = "greaterThanOrEqual"
+        ExpectedPublisher = "SignPath Foundation"
         AutoUpdate = $true
     }
     
@@ -324,6 +337,7 @@ $script:AppConfigurations = @{
         DetectionValueName = "DisplayVersion"
         DetectionOperator = "greaterThanOrEqual"
         VersionExtraction = "AppLocker"
+        ExpectedPublisher = "Google LLC"
         AutoUpdate = $true
     }
     
@@ -349,6 +363,7 @@ $script:AppConfigurations = @{
         DetectionFile = "KeePassXC.exe"
         DetectionOperator = "greaterThanOrEqual"
         Dependencies = @("VCRedist")
+        ExpectedPublisher = "DroidMonkey Apps"
         AutoUpdate = $true
     }
     
@@ -371,6 +386,7 @@ $script:AppConfigurations = @{
         DetectionValueName = "Installed"
         DetectionOperator = "exists"
         VersionExtraction = "AppLocker"
+        ExpectedPublisher = "Microsoft Corporation"
         HideFromPortal = $true
         AutoUpdate = $false
     }

--- a/Download-And-Package-Software.ps1
+++ b/Download-And-Package-Software.ps1
@@ -190,7 +190,10 @@ foreach ($appName in $allAppNames) {
         $installerTemp = Join-Path $appFolder $versionInfo.Filename
         
         Write-Host "  Downloading (version will be determined from file)..." -ForegroundColor Cyan
-        if (Invoke-FileDownload -Url $versionInfo.Url -OutputPath $installerTemp) {
+        if (Invoke-FileDownload -Url $versionInfo.Url -OutputPath $installerTemp `
+            -ExpectedSha256 $appConfig.ExpectedSha256 `
+            -EnforceSignatureCheck (-not $appConfig.AllowUnsignedInstaller) `
+            -ExpectedPublisher $appConfig.ExpectedPublisher) {
             
             # Check if extraction is required (Affinity Studio)
             if ($appConfig.ManualExtraction) {
@@ -369,7 +372,10 @@ foreach ($appName in $allAppNames) {
     }
     
     Write-Host "  Downloading version $($versionInfo.Version)..." -ForegroundColor Cyan
-    if (Invoke-FileDownload -Url $versionInfo.Url -OutputPath $installer) {
+    if (Invoke-FileDownload -Url $versionInfo.Url -OutputPath $installer `
+        -ExpectedSha256 $appConfig.ExpectedSha256 `
+        -EnforceSignatureCheck (-not $appConfig.AllowUnsignedInstaller) `
+        -ExpectedPublisher $appConfig.ExpectedPublisher) {
         # Clean up old files before packaging
         Remove-OldAppFiles -AppFolder $appFolder -KeepFileName (Split-Path $installer -Leaf)
         

--- a/SharedFunctions.ps1
+++ b/SharedFunctions.ps1
@@ -116,11 +116,88 @@ function Test-VersionExists {
     return $false
 }
 
+# Function to verify integrity of a downloaded installer file.
+# Checks SHA-256 hash (if provided) or Authenticode signature + optional publisher match.
+# Returns $true if the file passes verification, $false otherwise (fail closed).
+function Test-DownloadedFileIntegrity {
+    param(
+        [string]$FilePath,
+        [string]$ExpectedSha256,
+        [bool]$EnforceSignatureCheck = $true,
+        [string]$ExpectedPublisher
+    )
+
+    if (-not (Test-Path $FilePath)) {
+        Write-Host "Integrity check failed: file does not exist ($FilePath)" -ForegroundColor Red
+        return $false
+    }
+
+    # SHA-256 takes precedence — if provided, skip Authenticode (hash is a stronger guarantee)
+    if ($ExpectedSha256) {
+        try {
+            $actualHash = (Get-FileHash -Path $FilePath -Algorithm SHA256 -ErrorAction Stop).Hash
+            if ($actualHash -ne $ExpectedSha256.ToUpperInvariant()) {
+                Write-Host "Integrity check FAILED: SHA-256 mismatch for $(Split-Path $FilePath -Leaf)" -ForegroundColor Red
+                Write-Host "  Expected: $($ExpectedSha256.ToUpperInvariant())" -ForegroundColor Red
+                Write-Host "  Actual:   $actualHash" -ForegroundColor Red
+                return $false
+            }
+            Write-Host "Integrity check passed: SHA-256 verified." -ForegroundColor Green
+            return $true
+        }
+        catch {
+            Write-Host "Integrity check FAILED: unable to compute SHA-256 for $(Split-Path $FilePath -Leaf)" -ForegroundColor Red
+            Write-Host "  Error: $($_.Exception.Message)" -ForegroundColor Red
+            return $false
+        }
+    }
+
+    # Authenticode signature check (default path)
+    if ($EnforceSignatureCheck) {
+        try {
+            $signature = Get-AuthenticodeSignature -FilePath $FilePath -ErrorAction Stop
+        }
+        catch {
+            Write-Host "Integrity check FAILED: unable to verify Authenticode signature for $(Split-Path $FilePath -Leaf)" -ForegroundColor Red
+            Write-Host "  Error: $($_.Exception.Message)" -ForegroundColor Red
+            return $false
+        }
+
+        if ($signature.Status -ne 'Valid') {
+            Write-Host "Integrity check FAILED: Authenticode signature status is '$($signature.Status)' for $(Split-Path $FilePath -Leaf)" -ForegroundColor Red
+            return $false
+        }
+
+        # Publisher match (substring, case-insensitive)
+        if ($ExpectedPublisher) {
+            $subject = $signature.SignerCertificate.Subject
+            if (-not $subject -or $subject.IndexOf($ExpectedPublisher, [System.StringComparison]::OrdinalIgnoreCase) -lt 0) {
+                Write-Host "Integrity check FAILED: publisher mismatch for $(Split-Path $FilePath -Leaf)" -ForegroundColor Red
+                Write-Host "  Expected publisher containing: $ExpectedPublisher" -ForegroundColor Red
+                Write-Host "  Actual certificate subject:    $subject" -ForegroundColor Red
+                return $false
+            }
+            Write-Host "Integrity check passed: valid signature from '$ExpectedPublisher'." -ForegroundColor Green
+        }
+        else {
+            Write-Host "Integrity check passed: valid Authenticode signature." -ForegroundColor Green
+        }
+        return $true
+    }
+
+    # Signature enforcement explicitly disabled (AllowUnsignedInstaller = $true)
+    Write-Host "Integrity check skipped: signature enforcement disabled for this app." -ForegroundColor Yellow
+    return $true
+}
+
 # Function to download file with progress
 function Invoke-FileDownload {
     param(
         [string]$Url,
-        [string]$OutputPath
+        [string]$OutputPath,
+        [string]$ExpectedSha256,
+        [bool]$EnforceSignatureCheck = $true,
+        [string]$ExpectedPublisher
     )
     
     Write-Host "Downloading from: $Url" -ForegroundColor Cyan
@@ -135,6 +212,13 @@ function Invoke-FileDownload {
         $ProgressPreference = 'SilentlyContinue'  # Speeds up download
         Invoke-WebRequest -Uri $Url -OutFile $OutputPath -UseBasicParsing -ErrorAction Stop
         $ProgressPreference = 'Continue'
+
+        # Verify integrity before declaring success
+        if (-not (Test-DownloadedFileIntegrity -FilePath $OutputPath -ExpectedSha256 $ExpectedSha256 -EnforceSignatureCheck $EnforceSignatureCheck -ExpectedPublisher $ExpectedPublisher)) {
+            Write-Host "Removing unverified download: $(Split-Path $OutputPath -Leaf)" -ForegroundColor Red
+            Remove-Item -Path $OutputPath -Force -ErrorAction SilentlyContinue
+            return $false
+        }
         
         Write-Host "Download completed successfully!" -ForegroundColor Green
         return $true

--- a/SharedFunctions.ps1
+++ b/SharedFunctions.ps1
@@ -132,13 +132,21 @@ function Test-DownloadedFileIntegrity {
         return $false
     }
 
-    # SHA-256 takes precedence — if provided, skip Authenticode (hash is a stronger guarantee)
+    # SHA-256 takes precedence — if provided, Authenticode checks are intentionally skipped
+    # because an explicit hash pins the exact binary content (stronger than signature alone).
     if ($ExpectedSha256) {
+        # Normalize: strip whitespace, uppercase, validate 64 hex chars
+        $normalizedHash = ($ExpectedSha256 -replace '\s','').ToUpperInvariant()
+        if ($normalizedHash.Length -ne 64 -or $normalizedHash -notmatch '^[0-9A-F]{64}$') {
+            Write-Host "Integrity check FAILED: ExpectedSha256 is not a valid 64-character hex string." -ForegroundColor Red
+            Write-Host "  Received: $ExpectedSha256" -ForegroundColor Red
+            return $false
+        }
         try {
             $actualHash = (Get-FileHash -Path $FilePath -Algorithm SHA256 -ErrorAction Stop).Hash
-            if ($actualHash -ne $ExpectedSha256.ToUpperInvariant()) {
+            if ($actualHash -ne $normalizedHash) {
                 Write-Host "Integrity check FAILED: SHA-256 mismatch for $(Split-Path $FilePath -Leaf)" -ForegroundColor Red
-                Write-Host "  Expected: $($ExpectedSha256.ToUpperInvariant())" -ForegroundColor Red
+                Write-Host "  Expected: $normalizedHash" -ForegroundColor Red
                 Write-Host "  Actual:   $actualHash" -ForegroundColor Red
                 return $false
             }


### PR DESCRIPTION
## Summary

Addresses the security finding that downloaded installers are packaged for Intune deployment without integrity or authenticity verification. Adds post-download verification to `Invoke-FileDownload` so unverified binaries are deleted before packaging.

## Changes

### SharedFunctions.ps1
- **New function `Test-DownloadedFileIntegrity`** — verifies downloaded files via:
  - **SHA-256 hash** (when `ExpectedSha256` is set in app config) — normalized, validated as 64 hex chars, compared case-insensitively. When a hash matches, Authenticode is intentionally skipped (an explicit hash pins the exact binary content, which is a stronger guarantee than signature alone).
  - **Authenticode signature** (default path) — checks `Status -eq 'Valid'`, then optionally verifies `SignerCertificate.Subject` contains `ExpectedPublisher` (case-insensitive substring match).
  - **Fail closed** — all error paths return `False`; unverified downloads are deleted.
- **Updated `Invoke-FileDownload`** — three new parameters: `ExpectedSha256`, `EnforceSignatureCheck`, `ExpectedPublisher`. Calls `Test-DownloadedFileIntegrity` after download; deletes file and returns `False` on failure.

### Download-And-Package-Software.ps1
- Both `Invoke-FileDownload` call sites (AppLocker extraction path + standard download path) now pass integrity parameters from ``.

### AppConfig.ps1 (based on real Authenticode audit of existing installers)
- **`ExpectedPublisher`** added to 13 signed apps — verified against actual certificate Subject DNs:
  - Firefox (`Mozilla Corporation`), Chrome (`Google LLC`), GIMP (`Jernej`), Notepad++ (`NOTEPAD++`), Affinity (`Canva`), Audacity (`MuseCY`), LibreOffice (`Document Foundation`), OpenShot (`OpenShot Studios`), GeoGebra (`GeoGebra GmbH`), Stellarium (`SignPath Foundation`), GoogleDrive (`Google LLC`), KeePassXC (`DroidMonkey Apps`), VCRedist (`Microsoft Corporation`)
- **`AllowUnsignedInstaller = $true`** for 3 apps with missing/unreliable signatures: 7-Zip (not signed), VLC (unreliable status), Inkscape (self-signed/incomplete chain)

## Design decisions

| Decision | Rationale |
|---|---|
| SHA-256 skips Authenticode when provided | An explicit hash pins exact binary content — strictly stronger than signature. Running both adds no security value. |
| Substring match for publisher | Certificate Subject DNs vary across renewals (different CA, updated org format). Substring match against values like `Mozilla Corporation` or `GeoGebra GmbH` is resilient to DN format changes while being specific enough to prevent false positives. X.500 `O=` parsing would be fragile. |
| SHA-256 input is normalized | Strips whitespace, uppercases, validates 64 hex chars — prevents silent failures from copy-paste artifacts. |
| `AllowUnsignedInstaller` is explicit opt-out | Default behavior blocks unsigned installers. The 3 unsigned apps are annotated with comments explaining why. |
| `ExpectedSha256` not populated by default | Versions auto-update, so static hashes are impractical for routine use. The field exists for manual pinning scenarios. |

## Verification
- All three files pass `[System.Management.Automation.Language.Parser]::ParseFile()` (matches CI workflow)
- PowerShell 5.1 compatible (`Get-FileHash` is PS 4.0+, `Get-AuthenticodeSignature` is PS 2.0+)

## Follow-up considerations
- **Winget manifest hash lookup** for cross-origin verification of unsigned apps (7-Zip, VLC, Inkscape) — would fetch `InstallerSha256` from the `microsoft/winget-pkgs` repo on GitHub, providing a hash from a different trust domain than the download server
- **GPG signature verification** for VLC/7-Zip (both publish `.asc` files) — stronger than same-origin checksums but requires `gpg.exe` tooling