### PR TITLE
ci: pin actions to commit SHA and use cmiic/dependabot-automation

### DIFF
--- a/.github/workflows/pwsh-validate.yml
+++ b/.github/workflows/pwsh-validate.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Parse PowerShell scripts
         shell: pwsh


### PR DESCRIPTION
Pin GitHub Actions to commit SHAs for security and use cmiic/dependabot-automation for automated dependency updates.