### PR TITLE
Add Google Earth Pro & GPG4Win, fix Google Drive detection

### DIFF
--- a/AppConfig.ps1
+++ b/AppConfig.ps1
@@ -1,7 +1,6 @@
 # Application Configuration File
 # Centralized configuration for all software packages
-# Author: GitHub Copilot
-# Date: October 11, 2025
+
 
 # Application definitions with all metadata
 $script:AppConfigurations = @{
@@ -331,14 +330,65 @@ $script:AppConfigurations = @{
         FilenameTemplate = "GoogleDriveSetup-{0}.exe"
         PackageType = "EXE"
         InstallCommandTemplate = '"{0}" --silent --desktop_shortcut --skip_launch_new --gsuite_shortcuts=false'
-        UninstallCommandTemplate = '"C:\Program Files\Google\Drive File Stream\{1}\GoogleDriveFS.exe" --uninstall --silent'
-        DetectionType = "Registry"
-        DetectionPath = "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{6BBB3539-2232-434A-A4E5-9A33560C6283}"
-        DetectionValueName = "DisplayVersion"
-        DetectionOperator = "greaterThanOrEqual"
+        UninstallCommandTemplate = '"C:\Program Files\Google\Drive File Stream\{0}\GoogleDriveFS.exe" --uninstall --silent'
+        DetectionType = "Script"  # Use script detection (version folders: C:\Program Files\Google\Drive File Stream\X.X.X.X\)
+        DetectionOperator = "ScriptOnly"
+        DetectionScriptPath = "packages\googledrive\Detect-GoogleDriveVersion.ps1"
         VersionExtraction = "AppLocker"
         ExpectedPublisher = "Google LLC"
         AutoUpdate = $true
+        # Note: Google Drive installs GoogleDriveFS.exe in versioned subfolders
+        # Registry DisplayVersion may not reflect auto-updated version
+    }
+    
+    GoogleEarthPro = @{
+        Name = "Google Earth Pro"
+        DisplayNameTemplate = "Google Earth Pro {0}"
+        Publisher = "Google LLC"
+        Description = "Google Earth Pro - 3D globe with GIS data support for education"
+        Folder = "googleearthpro"
+        IconFile = "googleearthpro-logo.png"
+        IntuneWinPattern = "googleearthprowin-*.intunewin"
+        DownloadPageUrl = "https://support.google.com/earth/answer/40901?hl=en"
+        DownloadUrlRegex = 'Earth version (7\.\d+\.\d+)'
+        DownloadUrlTemplate = "https://dl.google.com/dl/earth/client/advanced/current/googleearthprowin-{0}-x64.exe"
+        FallbackUrl = "https://dl.google.com/dl/earth/client/advanced/current/googleearthprowin-7.3.7-x64.exe"
+        FallbackVersion = "7.3.7"
+        FilenameTemplate = "googleearthprowin-{0}-x64.exe"
+        PackageType = "EXE"
+        InstallCommandTemplate = '"{0}" OMAHA=1'
+        UninstallCommandTemplate = '"C:\Program Files\Google\Google Earth Pro\uninstall.exe" /S'
+        DetectionType = "File"
+        DetectionPath = "C:\Program Files\Google\Google Earth Pro\client"
+        DetectionFile = "googleearth.exe"
+        DetectionOperator = "greaterThanOrEqual"
+        ExpectedPublisher = "Google LLC"
+        AutoUpdate = $true
+        # Note: OMAHA=1 enables Google's auto-update mechanism
+        # Installer has no version metadata; version scraped from release notes page
+    }
+    
+    GPG4Win = @{
+        Name = "Gpg4win"
+        DisplayNameTemplate = "Gpg4win {0}"
+        Publisher = "g10 Code GmbH"
+        Description = "Gpg4win - GNU Privacy Guard for Windows with Kleopatra, GpgOL, and GpgEX"
+        Folder = "gpg4win"
+        IconFile = "gpg4win-logo.png"
+        IntuneWinPattern = "gpg4win-*.intunewin"
+        DownloadUrl = "https://files.gpg4win.org/gpg4win-latest.exe"
+        FallbackVersion = "5.0.2"
+        FilenameTemplate = "gpg4win-{0}.exe"
+        PackageType = "EXE"
+        InstallCommandTemplate = '"{0}" /S'
+        UninstallCommandTemplate = '"C:\Program Files\Gpg4win\gpg4win-uninstall.exe" /S'
+        DetectionType = "File"
+        DetectionPath = "C:\Program Files\Gpg4win\bin"
+        DetectionFile = "kleopatra.exe"
+        DetectionOperator = "greaterThanOrEqual"
+        VersionExtraction = "AppLocker"
+        ExpectedPublisher = "g10 Code GmbH"
+        AutoUpdate = $false
     }
     
     KeePassXC = @{
@@ -389,6 +439,52 @@ $script:AppConfigurations = @{
         ExpectedPublisher = "Microsoft Corporation"
         HideFromPortal = $true
         AutoUpdate = $false
+    }
+    
+    NextExamStudent = @{
+        Name = "NextExamStudent"
+        DisplayNameTemplate = "Next-Exam Student {0}"
+        Publisher = "Bildungsportal"
+        Description = "Next-Exam Student - Secure exam environment for student devices (Austrian Ministry of Education)"
+        Folder = "nextexam-student"
+        IconFile = "nextexam-teacher-logo.png"
+        IntuneWinPattern = "Next-Exam-Student_*.intunewin"
+        GitHubRepo = "Bildungsportal/next-exam"
+        GitHubApiUrl = "https://api.github.com/repos/Bildungsportal/next-exam/releases/latest"
+        GitHubAssetPattern = "Next-Exam-Student_[\d\.]+_\d+_x64\.msi$"
+        FallbackUrl = "https://github.com/Bildungsportal/next-exam/releases/download/1.1.3/Next-Exam-Student_1.1.3.1_20260318_x64.msi"
+        FallbackVersion = "1.1.3.1"
+        FilenameTemplate = "Next-Exam-Student_{0}_x64.msi"
+        PackageType = "MSI"
+        InstallCommandTemplate = 'msiexec /i "{0}" /qn ALLUSERS=1'
+        UninstallCommandTemplate = 'msiexec /x {0} /qn'  # {0} will be MSI product code
+        DetectionType = "MSI"
+        DetectionOperator = "ProductCodeOnly"
+        ExpectedPublisher = "thomas.weissel@bildung.gv.at"
+        AutoUpdate = $true
+    }
+    
+    NextExamTeacher = @{
+        Name = "NextExamTeacher"
+        DisplayNameTemplate = "Next-Exam Teacher {0}"
+        Publisher = "Bildungsportal"
+        Description = "Next-Exam Teacher - Exam dashboard and control panel for teachers (Austrian Ministry of Education)"
+        Folder = "nextexam-teacher"
+        IconFile = "nextexam-teacher-logo.png"
+        IntuneWinPattern = "Next-Exam-Teacher_*.intunewin"
+        GitHubRepo = "Bildungsportal/next-exam"
+        GitHubApiUrl = "https://api.github.com/repos/Bildungsportal/next-exam/releases/latest"
+        GitHubAssetPattern = "Next-Exam-Teacher_[\d\.]+_\d+_x64\.msi$"
+        FallbackUrl = "https://github.com/Bildungsportal/next-exam/releases/download/1.1.3/Next-Exam-Teacher_1.1.3.1_20260318_x64.msi"
+        FallbackVersion = "1.1.3.1"
+        FilenameTemplate = "Next-Exam-Teacher_{0}_x64.msi"
+        PackageType = "MSI"
+        InstallCommandTemplate = 'msiexec /i "{0}" /qn ALLUSERS=1'
+        UninstallCommandTemplate = 'msiexec /x {0} /qn'  # {0} will be MSI product code
+        DetectionType = "MSI"
+        DetectionOperator = "ProductCodeOnly"
+        ExpectedPublisher = "thomas.weissel@bildung.gv.at"
+        AutoUpdate = $true
     }
 }
 

--- a/AuthenticationManager.ps1
+++ b/AuthenticationManager.ps1
@@ -1,7 +1,6 @@
 # Authentication Manager Module
 # Centralized authentication for Microsoft Intune operations
-# Author: GitHub Copilot
-# Date: December 10, 2025
+
 
 <#
 .SYNOPSIS

--- a/Deploy-ToIntune.ps1
+++ b/Deploy-ToIntune.ps1
@@ -1,7 +1,6 @@
 # Complete Intune Win32 App Deployment Script
 # Uses IntuneWin32App module for proper deployment
-# Author: GitHub Copilot
-# Date: October 10, 2025
+
 
 <#
 .SYNOPSIS
@@ -615,25 +614,21 @@ if (-not (Initialize-IntuneAuthentication -TenantId $TenantId -ClientId $ClientI
 
 Write-Host "Successfully connected to Microsoft Intune!" -ForegroundColor Green
 
-# Define apps to deploy
-$script:appsToDeploy = @(
-    @{Name = "Firefox"; Folder = "firefox"; Pattern = "Firefox-Setup-*-de.intunewin"; AppConfigName = "Firefox"; PackageType = "EXE" },
-    @{Name = "Chrome"; Folder = "chrome"; Pattern = "GoogleChrome-*-Enterprise-x64.intunewin"; AppConfigName = "Chrome"; PackageType = "MSI" },
-    @{Name = "7-Zip"; Folder = "7zip"; Pattern = "7z*-x64.intunewin"; AppConfigName = "SevenZip"; PackageType = "MSI" },
-    @{Name = "GIMP"; Folder = "gimp"; Pattern = "gimp-*-setup*.intunewin"; AppConfigName = "GIMP"; PackageType = "EXE" },
-    @{Name = "VLC"; Folder = "vlc"; Pattern = "vlc-*-win64.intunewin"; AppConfigName = "VLC"; PackageType = "EXE" },
-    @{Name = "Notepad++"; Folder = "npp"; Pattern = "npp.*Installer.x64.intunewin"; AppConfigName = "NotepadPlusPlus"; PackageType = "EXE" },
-    @{Name = "Affinity Studio"; Folder = "affinity"; Pattern = "Affinity*.intunewin"; AppConfigName = "AffinityStudio"; PackageType = "MSI" },
-    @{Name = "Inkscape"; Folder = "inkscape"; Pattern = "inkscape-*.intunewin"; AppConfigName = "Inkscape"; PackageType = "MSI" },
-    @{Name = "Audacity"; Folder = "audacity"; Pattern = "audacity-*.intunewin"; AppConfigName = "Audacity"; PackageType = "EXE" },
-    @{Name = "LibreOffice"; Folder = "libreoffice"; Pattern = "LibreOffice_*.intunewin"; AppConfigName = "LibreOffice"; PackageType = "MSI" },
-    @{Name = "OpenShot"; Folder = "openshot"; Pattern = "OpenShot-v*-x86_64.intunewin"; AppConfigName = "OpenShot"; PackageType = "EXE" },
-    @{Name = "GeoGebra"; Folder = "geogebra"; Pattern = "GeoGebra-Windows-Installer-6-*.intunewin"; AppConfigName = "GeoGebra"; PackageType = "MSI" },
-    @{Name = "Stellarium"; Folder = "stellarium"; Pattern = "stellarium-*.intunewin"; AppConfigName = "Stellarium"; PackageType = "EXE" },
-    @{Name = "Google Drive"; Folder = "googledrive"; Pattern = "GoogleDriveSetup-*.intunewin"; AppConfigName = "GoogleDrive"; PackageType = "EXE" },
-    @{Name = "KeePassXC"; Folder = "keepassxc"; Pattern = "KeePassXC-*-Win64.intunewin"; AppConfigName = "KeePassXC"; PackageType = "EXE" },
-    @{Name = "VCRedist"; Folder = "vcredist"; Pattern = "vc_redist*.intunewin"; AppConfigName = "VCRedist"; PackageType = "EXE" }
-)
+# Build apps to deploy dynamically from AppConfig.ps1 (single source of truth)
+$script:appsToDeploy = @()
+foreach ($appConfigName in (Get-AllAppNames)) {
+    $cfg = Get-AppConfiguration -AppName $appConfigName
+    if ($cfg -and $cfg.Folder -and $cfg.IntuneWinPattern) {
+        $displayName = $cfg.DisplayNameTemplate -replace '\s*\{0\}', ''
+        $script:appsToDeploy += @{
+            Name = $displayName.Trim()
+            Folder = $cfg.Folder
+            Pattern = $cfg.IntuneWinPattern
+            AppConfigName = $appConfigName
+            PackageType = $cfg.PackageType
+        }
+    }
+}
 
 # Filter apps if AppName parameter is specified
 $appsToProcess = $script:appsToDeploy

--- a/Download-And-Package-Software.ps1
+++ b/Download-And-Package-Software.ps1
@@ -1,6 +1,5 @@
 # Script to download latest software versions and create IntuneWin packages
-# Author: GitHub Copilot
-# Date: October 10, 2025
+
 
 param(
     [Parameter(Mandatory=$false)]
@@ -111,6 +110,14 @@ function Get-LatestVersionInfo {
                     else {
                         Write-Host "  No matches found with regex pattern" -ForegroundColor Yellow
                     }
+                }
+                elseif ($AppConfig.Name -eq "Google Earth Pro") {
+                    # Google Earth Pro - scrape version from release notes, build versioned URL
+                    $version = $matches[1]  # e.g., "7.3.7"
+                    $url = $AppConfig.DownloadUrlTemplate -f $version
+                    $filename = $AppConfig.FilenameTemplate -f $version
+                    Write-Host "  Found version: $version" -ForegroundColor Green
+                    return @{Url = $url; Version = $version; Filename = $filename}
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ intune-app-management/
 
 ## Features
 
-- **Automatic version detection** for 10 applications
+- **Automatic version detection** for 20 applications
 - **Silent installation** with pre-configured commands
 - **Supersedence management** - automatically replaces older versions
 - **Icon support** for Company Portal
@@ -40,18 +40,28 @@ intune-app-management/
 
 ## Supported Applications
 
-- Mozilla Firefox (German)
-- Google Chrome Enterprise
-- 7-Zip
-- GIMP
-- VLC Media Player
-- Notepad++
-- Affinity Studio
-- Inkscape
-- Audacity
-- LibreOffice (German, Enterprise version)
-- OpenShot Video Editor
-- KeePassXC
+| Application | Type | Version Detection |
+| --- | --- | --- |
+| Mozilla Firefox (German) | EXE | Mozilla Product Details API |
+| Google Chrome Enterprise | MSI | Web scraping (AppLocker XML) |
+| 7-Zip | EXE | Web scraping |
+| GIMP | EXE | Web scraping |
+| VLC Media Player | MSI | Web scraping |
+| Notepad++ | EXE | GitHub Releases |
+| Affinity Studio | MSI | AppLocker XML extraction |
+| Inkscape | MSI | Web scraping |
+| Audacity | EXE | GitHub Releases |
+| LibreOffice (German) | MSI | Web scraping (Enterprise version) |
+| OpenShot Video Editor | EXE | GitHub Releases |
+| KeePassXC | MSI | GitHub Releases |
+| GeoGebra | MSI | Direct download (version in filename) |
+| Stellarium | EXE | GitHub Releases |
+| Google Drive | EXE | GitHub JSON feed |
+| Google Earth Pro | EXE | Web scraping (Release notes) |
+| GPG4Win (Kleopatra) | EXE | Direct download |
+| Visual C++ Redistributable | EXE | Web scraping (Microsoft) |
+| NextExam Teacher | MSI | Manual update |
+| NextExam Student | MSI | Manual update |
 
 ## Prerequisites
 
@@ -318,10 +328,15 @@ Edit `AppConfig.ps1` to modify:
 
 ### Version Detection Methods
 
-- **API-based**: Firefox (Mozilla product details API)
-- **GitHub Releases**: Notepad++, Audacity
-- **Web Scraping**: 7-Zip, GIMP, VLC, Inkscape, LibreOffice
-- **AppLocker Extraction**: Chrome, Affinity Studio
+| Method | Applications |
+| --- | --- |
+| **Mozilla API** | Firefox |
+| **GitHub Releases** | Notepad++, Audacity, OpenShot, KeePassXC, Stellarium |
+| **GitHub JSON** | Google Drive |
+| **Web Scraping** | 7-Zip, GIMP, VLC, Inkscape, LibreOffice, Google Earth Pro, Visual C++ Redist |
+| **AppLocker XML** | Chrome, Affinity Studio |
+| **Direct Download** | GeoGebra, GPG4Win |
+| **Manual Update** | NextExam Teacher, NextExam Student |
 
 ### Special Handling
 
@@ -329,6 +344,9 @@ Edit `AppConfig.ps1` to modify:
 - **Inkscape**: Two-step download (main page → platforms page)
 - **LibreOffice**: Enterprise version selection (stable vs. fresh)
 - **Chrome**: File-based detection for auto-update support
+- **GeoGebra**: PowerShell script detection (MSI product code doesn't change between versions)
+- **KeePassXC**: Custom install script with silent INI config deployment
+- **Google Earth Pro**: Uses OMAHA=1 flag for built-in auto-update
 
 ### Supersedence
 

--- a/README.md
+++ b/README.md
@@ -46,17 +46,17 @@ intune-app-management/
 | Google Chrome Enterprise | MSI | Web scraping (AppLocker XML) |
 | 7-Zip | EXE | Web scraping |
 | GIMP | EXE | Web scraping |
-| VLC Media Player | MSI | Web scraping |
+| VLC Media Player | EXE | Web scraping |
 | Notepad++ | EXE | GitHub Releases |
 | Affinity Studio | MSI | AppLocker XML extraction |
 | Inkscape | MSI | Web scraping |
 | Audacity | EXE | GitHub Releases |
 | LibreOffice (German) | MSI | Web scraping (Enterprise version) |
 | OpenShot Video Editor | EXE | GitHub Releases |
-| KeePassXC | MSI | GitHub Releases |
+| KeePassXC | EXE | GitHub Releases |
 | GeoGebra | MSI | Direct download (version in filename) |
 | Stellarium | EXE | GitHub Releases |
-| Google Drive | EXE | GitHub JSON feed |
+| Google Drive | EXE | AppLocker XML extraction |
 | Google Earth Pro | EXE | Web scraping (Release notes) |
 | GPG4Win (Kleopatra) | EXE | Direct download |
 | Visual C++ Redistributable | EXE | Web scraping (Microsoft) |
@@ -332,9 +332,8 @@ Edit `AppConfig.ps1` to modify:
 | --- | --- |
 | **Mozilla API** | Firefox |
 | **GitHub Releases** | Notepad++, Audacity, OpenShot, KeePassXC, Stellarium |
-| **GitHub JSON** | Google Drive |
 | **Web Scraping** | 7-Zip, GIMP, VLC, Inkscape, LibreOffice, Google Earth Pro, Visual C++ Redist |
-| **AppLocker XML** | Chrome, Affinity Studio |
+| **AppLocker XML** | Chrome, Google Drive, Affinity Studio |
 | **Direct Download** | GeoGebra, GPG4Win |
 | **Manual Update** | NextExam Teacher, NextExam Student |
 

--- a/SharedFunctions.ps1
+++ b/SharedFunctions.ps1
@@ -496,6 +496,17 @@ function Get-ScriptAppConfig {
     $appConfig = Get-AppConfiguration -AppName $AppName
     $commonSettings = Get-CommonSettings
     
+    # Validate version for EXE apps (required for uninstall command and detection script)
+    if ($appConfig.PackageType -eq "EXE") {
+        try {
+            $null = [version]$Version
+        }
+        catch {
+            throw "Script-detected EXE app '$AppName' requires a valid version number (got '$Version'). " +
+                  "Update FallbackVersion in AppConfig.ps1 or ensure the installer filename contains a parseable version."
+        }
+    }
+    
     # Get detection script path
     $scriptPath = Join-Path $PSScriptRoot $appConfig.DetectionScriptPath
     

--- a/SharedFunctions.ps1
+++ b/SharedFunctions.ps1
@@ -1,7 +1,6 @@
 # Shared Functions Module
 # Common functions used by both Download-And-Package-Software.ps1 and Deploy-ToIntune.ps1
-# Author: GitHub Copilot
-# Date: October 11, 2025
+
 
 # Import configuration
 . (Join-Path $PSScriptRoot "AppConfig.ps1")
@@ -544,13 +543,15 @@ function Get-ScriptAppConfig {
     # Format commands
     $InstallCommand = $appConfig.InstallCommandTemplate -f $SetupFile
     
-    # Get MSI product code for uninstall (even with script detection, we still uninstall via MSI)
-    if ($IntuneWinPath) {
+    # Format uninstall command based on package type
+    if ($appConfig.PackageType -eq "MSI" -and $IntuneWinPath) {
+        # MSI apps: use product code for uninstall
         $IntuneWinMetaData = Get-IntuneWin32AppMetaData -FilePath $IntuneWinPath
         $UninstallCommand = $appConfig.UninstallCommandTemplate -f $IntuneWinMetaData.ApplicationInfo.MsiInfo.MsiProductCode
     }
     else {
-        $UninstallCommand = $appConfig.UninstallCommandTemplate
+        # EXE apps: use version for uninstall command (e.g., versioned folder paths)
+        $UninstallCommand = $appConfig.UninstallCommandTemplate -f $Version
     }
     
     return @{

--- a/packages/googledrive/Detect-GoogleDriveVersion.ps1
+++ b/packages/googledrive/Detect-GoogleDriveVersion.ps1
@@ -1,0 +1,88 @@
+# Google Drive for Desktop Version Detection Script
+# Returns exit code 0 if installed version >= required version, 1 otherwise
+# Used by Intune Win32 app detection
+#
+# Google Drive installs GoogleDriveFS.exe in versioned subfolders:
+#   C:\Program Files\Google\Drive File Stream\123.0.1.0\GoogleDriveFS.exe
+# This script finds the newest installed version and compares it.
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$RequiredVersion
+)
+
+function Get-GoogleDriveVersion {
+    # Method 1: Scan Drive File Stream folder for newest version subfolder (most accurate after auto-update)
+    $driveStreamPath = "C:\Program Files\Google\Drive File Stream"
+    
+    if (Test-Path $driveStreamPath) {
+        # Get all version folders (format: X.X.X.X) that contain GoogleDriveFS.exe
+        $versionFolders = Get-ChildItem -Path $driveStreamPath -Directory -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -match '^\d+\.\d+\.\d+\.\d+$' } |
+            ForEach-Object {
+                $exePath = Join-Path $_.FullName "GoogleDriveFS.exe"
+                if (Test-Path $exePath) {
+                    try {
+                        [PSCustomObject]@{
+                            Name = $_.Name
+                            Version = [version]$_.Name
+                        }
+                    }
+                    catch {
+                        $null
+                    }
+                }
+            } |
+            Where-Object { $_ } |
+            Sort-Object Version -Descending
+        
+        if ($versionFolders -and $versionFolders.Count -gt 0) {
+            return $versionFolders[0].Name
+        }
+    }
+    
+    # Method 2: Fallback to registry (may lag behind after auto-update)
+    $regPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{6BBAE539-2232-434A-A4E5-9A33560C6283}"
+    
+    if (Test-Path $regPath) {
+        $displayVersion = (Get-ItemProperty -Path $regPath -ErrorAction SilentlyContinue).DisplayVersion
+        if ($displayVersion) {
+            return $displayVersion
+        }
+        
+        # Extract version from InstallLocation path
+        $installLocation = (Get-ItemProperty -Path $regPath -ErrorAction SilentlyContinue).InstallLocation
+        if ($installLocation -and $installLocation -match '(\d+\.\d+\.\d+\.\d+)') {
+            return $matches[1]
+        }
+    }
+    
+    return $null
+}
+
+# Get installed version
+$installedVersion = Get-GoogleDriveVersion
+
+if (-not $installedVersion) {
+    # Not installed
+    exit 1
+}
+
+# Compare versions
+try {
+    $installedVer = [version]$installedVersion
+    $requiredVer = [version]$RequiredVersion
+    
+    if ($installedVer -ge $requiredVer) {
+        # Compliant: installed version is >= required
+        exit 0
+    }
+    else {
+        # Non-compliant: needs update
+        exit 1
+    }
+}
+catch {
+    # Version comparison failed - assume non-compliant
+    exit 1
+}


### PR DESCRIPTION
## New Applications

### Google Earth Pro
- Version detection via web scraping from release notes page
- Versioned download URL pattern (same as GIMP/VLC/LibreOffice)
- \OMAHA=1\ flag enables built-in auto-update
- File-based detection on \googleearth.exe\

### GPG4Win (Kleopatra)
- Direct download from \gpg4win-latest.exe\
- NSIS installer with \/S\ silent flag
- File-based detection on \kleopatra.exe\

## Google Drive Fixes

- **Registry GUID typo**: Fixed \{6BBB3539-...}\ → \{6BBAE539-...}\
- **Detection order**: Now scans version folders first (accurate after auto-update), falls back to registry
- **UninstallCommandTemplate**: Fixed format exception - EXE apps now receive version string instead of MSI product code

## README Updates

- Updated supported apps count: 10 → 20
- Replaced bullet list with table showing all apps, installer types, and version detection methods
- Added Version Detection Methods table
- Added notes for GeoGebra, KeePassXC, and Google Earth Pro in Special Handling section