### PR TITLE
chore(ci): add 15 minute job timeouts to all workflow jobs

### DIFF
--- a/.github/workflows/pwsh-validate.yml
+++ b/.github/workflows/pwsh-validate.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   pwsh-validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
- Add `timeout-minutes: 15` to every job. Without it a hung job holds a runner for the 6 h default.