### PR TITLE
ci: drop the redundant push trigger from CI

### DIFF
--- a/.github/workflows/pwsh-validate.yml
+++ b/.github/workflows/pwsh-validate.yml
@@ -2,10 +2,8 @@ name: PowerShell Validation
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
   merge_group:
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Branch protection already guarantees these checks passed on the pull
request before it could merge, so re-running them on push to the default
branch only duplicates work and burns runner minutes. Required checks are
unaffected: they are produced by the pull_request trigger, which stays.

Adds workflow_dispatch so the workflow can still be run by hand.