### PR TITLE
Add Pester 5 test suite and CI job

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,4 +31,6 @@
 ## Build & Test
 
 - Syntax validation: `[System.Management.Automation.Language.Parser]::ParseFile()` — used in CI via `.github/workflows/pwsh-validate.yml`
-- No Pester test suite currently
+- Pester 5 test suite in `tests/` (run: `Invoke-Pester -Path tests`). CI runs it on `windows-latest` with the IntuneWin32App module installed, excluding tag `LocalOnly` (tests that need real installer binaries from `packages/`, which are not in git).
+- Test files copy the scripts under test to `$TestDrive` before dot-sourcing, so `$PSScriptRoot`-derived paths (`intune-tenants.json`, `AppVersions.json`, detection scripts) stay sandboxed — keep that pattern when adding tests.
+- `tests/AppConfig.Tests.ps1` is the golden guard for app-config generation: it pins the detection/requirement rule shapes and command lines that refactors (issue #8 interop isolation, #9 native Graph migration) must preserve. If it fails after an intentional contract change, update the assertions deliberately.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,6 +31,6 @@
 ## Build & Test
 
 - Syntax validation: `[System.Management.Automation.Language.Parser]::ParseFile()` — used in CI via `.github/workflows/pwsh-validate.yml`
-- Pester 5 test suite in `tests/` (run: `Invoke-Pester -Path tests`). CI runs it on `windows-latest` with the IntuneWin32App module installed, excluding tag `LocalOnly` (tests that need real installer binaries from `packages/`, which are not in git).
+- Pester test suite in `tests/` (Pester v5+ syntax; run: `Invoke-Pester -Path tests`). CI runs it on `windows-latest` with pinned module versions (Pester 6.0.1, IntuneWin32App 1.5.0 — bump the pins in `pwsh-validate.yml` deliberately), excluding tag `LocalOnly` (tests that need real installer binaries from `packages/`, which are not in git).
 - Test files copy the scripts under test to `$TestDrive` before dot-sourcing, so `$PSScriptRoot`-derived paths (`intune-tenants.json`, `AppVersions.json`, detection scripts) stay sandboxed — keep that pattern when adding tests.
 - `tests/AppConfig.Tests.ps1` is the golden guard for app-config generation: it pins the detection/requirement rule shapes and command lines that refactors (issue #8 interop isolation, #9 native Graph migration) must preserve. If it fails after an intentional contract change, update the assertions deliberately.

--- a/.github/workflows/pwsh-validate.yml
+++ b/.github/workflows/pwsh-validate.yml
@@ -54,16 +54,18 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # Versions are pinned so the golden-config tests (which execute the real
+      # IntuneWin32App rule builders) stay deterministic. Bump them deliberately.
       - name: Install test dependencies
         shell: pwsh
         run: |
-          Install-Module -Name Pester -MinimumVersion 5.5.0 -Force -SkipPublisherCheck -Scope CurrentUser
-          Install-Module -Name IntuneWin32App -Force -Scope CurrentUser
+          Install-Module -Name Pester -RequiredVersion 6.0.1 -Force -SkipPublisherCheck -Scope CurrentUser
+          Install-Module -Name IntuneWin32App -RequiredVersion 1.5.0 -Force -Scope CurrentUser
 
       - name: Run Pester tests
         shell: pwsh
         run: |
-          Import-Module Pester -MinimumVersion 5.5.0
+          Import-Module Pester -RequiredVersion 6.0.1
           $config = New-PesterConfiguration
           $config.Run.Path = 'tests'
           $config.Run.Exit = $true

--- a/.github/workflows/pwsh-validate.yml
+++ b/.github/workflows/pwsh-validate.yml
@@ -45,3 +45,28 @@ jobs:
           if ($hadErrors) {
             throw "PowerShell syntax validation failed."
           }
+
+  pester:
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install test dependencies
+        shell: pwsh
+        run: |
+          Install-Module -Name Pester -MinimumVersion 5.5.0 -Force -SkipPublisherCheck -Scope CurrentUser
+          Install-Module -Name IntuneWin32App -Force -Scope CurrentUser
+
+      - name: Run Pester tests
+        shell: pwsh
+        run: |
+          Import-Module Pester -MinimumVersion 5.5.0
+          $config = New-PesterConfiguration
+          $config.Run.Path = 'tests'
+          $config.Run.Exit = $true
+          $config.Filter.ExcludeTag = 'LocalOnly'
+          $config.Output.Verbosity = 'Detailed'
+          Invoke-Pester -Configuration $config

--- a/.gitignore
+++ b/.gitignore
@@ -94,7 +94,6 @@ TenantDeployments.json
 
 Download-AppLogos.ps1
 
-/tests/*
 packages/Lehrerkopierer/*
 packages/Schuelerkopierer/*
 

--- a/tests/AppConfig.Tests.ps1
+++ b/tests/AppConfig.Tests.ps1
@@ -1,0 +1,180 @@
+#Requires -Version 7.4
+
+# Golden-config guard: characterizes the exact detection/requirement rule shapes and
+# command lines that Get-MsiAppConfig / Get-FileAppConfig / Get-ScriptAppConfig produce
+# for one representative app per detection type. These tests pin the contract that the
+# issue #8 interop refactor (and later the #9 native Graph migration) must preserve.
+#
+# Requires the IntuneWin32App module (rule builders are executed for real).
+# Get-IntuneWin32AppMetaData is mocked so no .intunewin fixture binaries are needed.
+
+BeforeAll {
+    Import-Module IntuneWin32App -ErrorAction Stop
+
+    # Copy the scripts to TestDrive so $PSScriptRoot-derived paths (AppVersions.json,
+    # detection scripts) resolve inside the sandbox, and skip the version-cache overlay
+    # so FallbackVersion values stay at their deterministic seeds.
+    $repoRoot = Split-Path $PSScriptRoot -Parent
+    $workDir = Join-Path $TestDrive 'repo'
+    New-Item -ItemType Directory -Path (Join-Path $workDir 'packages\geogebra') -Force | Out-Null
+    Copy-Item (Join-Path $repoRoot 'SharedFunctions.ps1') $workDir
+    Copy-Item (Join-Path $repoRoot 'AppConfig.ps1') $workDir
+    Copy-Item (Join-Path $repoRoot 'packages\geogebra\Detect-GeoGebraVersion.ps1') (Join-Path $workDir 'packages\geogebra')
+    . (Join-Path $workDir 'SharedFunctions.ps1')
+
+    $mockProductCode = '{AAAAAAAA-BBBB-CCCC-DDDD-EEEEFFFF0000}'
+
+    # Get-IntuneWin32AppMetaData validates that -FilePath exists even when mocked
+    # (Pester mock proxies keep parameter validation), so provide a real empty file.
+    $dummyIntuneWin = Join-Path $TestDrive 'dummy.intunewin'
+    New-Item -ItemType File -Path $dummyIntuneWin -Force | Out-Null
+}
+
+Describe 'App config generation (golden guard for issue #8/#9 refactors)' {
+    BeforeAll {
+        Mock Get-IntuneWin32AppMetaData {
+            [xml]@"
+<ApplicationInfo>
+  <SetupFile>mock-setup.msi</SetupFile>
+  <MsiInfo>
+    <MsiProductCode>{AAAAAAAA-BBBB-CCCC-DDDD-EEEEFFFF0000}</MsiProductCode>
+    <MsiProductVersion>26.02.00.0</MsiProductVersion>
+    <MsiPublisher>Mock Publisher GmbH</MsiPublisher>
+  </MsiInfo>
+</ApplicationInfo>
+"@
+        }
+    }
+
+    Context 'Get-MsiAppConfig - SevenZip (pure MSI, ProductCodeOnly detection)' {
+        BeforeAll {
+            $config = Get-MsiAppConfig -AppName 'SevenZip' -Version '26.02' -SetupFile '7z2602-x64.msi' -IntuneWinPath $dummyIntuneWin
+        }
+
+        It 'builds an MSI product-code detection rule' {
+            $rule = $config.DetectionRules
+            $rule.'@odata.type' | Should -Be '#microsoft.graph.win32LobAppProductCodeDetection'
+            $rule.productCode | Should -Be $mockProductCode
+            $rule.productVersionOperator | Should -Be 'notConfigured'
+        }
+
+        It 'takes version and publisher from the MSI metadata' {
+            $config.AppVersion | Should -Be '26.02.00.0'
+            $config.Publisher | Should -Be 'Mock Publisher GmbH'
+        }
+
+        It 'formats the display name with the major version only' {
+            $config.DisplayName | Should -Be '7-Zip 26'
+        }
+
+        It 'uses the MSI product code in the uninstall command' {
+            $config.UninstallCommandLine | Should -Be "msiexec /x $mockProductCode /qn"
+        }
+    }
+
+    Context 'Get-MsiAppConfig - Chrome (hybrid MSI with file-based detection)' {
+        BeforeAll {
+            $config = Get-MsiAppConfig -AppName 'Chrome' -Version '151.0.7922.109' -SetupFile 'GoogleChrome-151.0.7922.109-Enterprise-x64.msi' -IntuneWinPath $dummyIntuneWin
+        }
+
+        It 'builds a file-system version detection rule instead of a product-code rule' {
+            $rule = $config.DetectionRules
+            $rule.'@odata.type' | Should -Be '#microsoft.graph.win32LobAppFileSystemDetection'
+            $rule.path | Should -Be 'C:\Program Files\Google\Chrome\Application'
+            $rule.fileOrFolderName | Should -Be 'chrome.exe'
+            $rule.detectionType | Should -Be 'version'
+            $rule.operator | Should -Be 'greaterThanOrEqual'
+            $rule.detectionValue | Should -Be '151.0.7922.109'
+            $rule.check32BitOn64System | Should -BeFalse
+        }
+
+        It 'uses the provided version (not MSI metadata) because auto-update outruns the MSI version' {
+            $config.AppVersion | Should -Be '151.0.7922.109'
+        }
+
+        It 'formats the display name with the major version only' {
+            $config.DisplayName | Should -Be 'Google Chrome 151'
+        }
+
+        It 'still uses the MSI product code for uninstall' {
+            $config.UninstallCommandLine | Should -Be "msiexec /x $mockProductCode /qn"
+        }
+    }
+
+    Context 'Get-FileAppConfig - Firefox (EXE with file-based detection)' {
+        BeforeAll {
+            $config = Get-FileAppConfig -AppName 'Firefox' -Version '143.0.1' -SetupFile 'Firefox-Setup-143.0.1-de.exe'
+        }
+
+        It 'builds a file-system version detection rule' {
+            $rule = $config.DetectionRules
+            $rule.'@odata.type' | Should -Be '#microsoft.graph.win32LobAppFileSystemDetection'
+            $rule.path | Should -Be 'C:\Program Files\Mozilla Firefox'
+            $rule.fileOrFolderName | Should -Be 'firefox.exe'
+            $rule.operator | Should -Be 'greaterThanOrEqual'
+            $rule.detectionValue | Should -Be '143.0.1'
+        }
+
+        It 'formats install and uninstall command lines from the templates' {
+            $config.InstallCommandLine | Should -Be '"Firefox-Setup-143.0.1-de.exe" /S'
+            $config.UninstallCommandLine | Should -Be '"C:\Program Files\Mozilla Firefox\uninstall\helper.exe" /S'
+        }
+
+        It 'keeps the full version as AppVersion but only the major version in the display name' {
+            $config.AppVersion | Should -Be '143.0.1'
+            $config.DisplayName | Should -Be 'Mozilla Firefox 143 (German)'
+        }
+    }
+
+    Context 'Get-FileAppConfig - VCRedist (registry existence detection)' {
+        BeforeAll {
+            $config = Get-FileAppConfig -AppName 'VCRedist' -Version '14.40.33816' -SetupFile 'vc_redist.x64-14.40.33816.exe'
+        }
+
+        It 'builds a registry existence detection rule' {
+            $rule = $config.DetectionRules
+            $rule.'@odata.type' | Should -Be '#microsoft.graph.win32LobAppRegistryDetection'
+            $rule.keyPath | Should -Be 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\X64'
+            $rule.valueName | Should -Be 'Installed'
+            $rule.detectionType | Should -Be 'exists'
+            $rule.operator | Should -Be 'notConfigured'
+        }
+    }
+
+    Context 'Get-ScriptAppConfig - GeoGebra (PowerShell script detection, MSI package)' {
+        BeforeAll {
+            $config = Get-ScriptAppConfig -AppName 'GeoGebra' -Version '6.0.906.2' -SetupFile 'GeoGebra-Windows-Installer-6-6.0.906.2.msi' -IntuneWinPath $dummyIntuneWin
+        }
+
+        It 'builds a PowerShell script detection rule' {
+            $rule = $config.DetectionRules
+            $rule.'@odata.type' | Should -Be '#microsoft.graph.win32LobAppPowerShellScriptDetection'
+            $rule.enforceSignatureCheck | Should -BeFalse
+            $rule.runAs32Bit | Should -BeFalse
+        }
+
+        It 'injects the required version into the detection script content' {
+            $scriptText = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($config.DetectionRules.scriptContent))
+            $scriptText | Should -Match ([regex]::Escape("`$RequiredVersion = '6.0.906.2'"))
+            $scriptText | Should -Not -Match 'Parameter\(Mandatory' -Because 'the mandatory param block must be replaced by the injected version'
+        }
+
+        It 'uses the MSI product code for uninstall (MSI package type)' {
+            $config.UninstallCommandLine | Should -Be "msiexec /x $mockProductCode /qn"
+        }
+    }
+
+    Context 'Common settings applied to every generated config' {
+        It 'stamps install experience, restart behavior, and an x64/Win11 requirement rule' {
+            foreach ($config in @(
+                (Get-MsiAppConfig -AppName 'SevenZip' -Version '26.02' -SetupFile '7z2602-x64.msi' -IntuneWinPath $dummyIntuneWin),
+                (Get-FileAppConfig -AppName 'Firefox' -Version '143.0.1' -SetupFile 'Firefox-Setup-143.0.1-de.exe')
+            )) {
+                $config.InstallExperience | Should -Be 'system'
+                $config.RestartBehavior | Should -Be 'suppress'
+                $config.RequirementRule.allowedArchitectures | Should -Be 'x64'
+                $config.RequirementRule.minimumSupportedWindowsRelease | Should -Be 'Windows11_21H2'
+            }
+        }
+    }
+}

--- a/tests/SharedFunctions.Tests.ps1
+++ b/tests/SharedFunctions.Tests.ps1
@@ -1,0 +1,148 @@
+#Requires -Version 7.4
+
+# Tests for the pure-logic helpers in SharedFunctions.ps1: version cache writes,
+# existing-package version checks, and download integrity verification.
+# Scripts are copied to TestDrive so AppVersions.json writes land in the sandbox,
+# never in the repo checkout.
+
+BeforeAll {
+    $repoRoot = Split-Path $PSScriptRoot -Parent
+    $workDir = Join-Path $TestDrive 'repo'
+    New-Item -ItemType Directory -Path $workDir -Force | Out-Null
+    Copy-Item (Join-Path $repoRoot 'SharedFunctions.ps1') $workDir
+    Copy-Item (Join-Path $repoRoot 'AppConfig.ps1') $workDir
+    . (Join-Path $workDir 'SharedFunctions.ps1')
+    $cachePath = Join-Path $workDir 'AppVersions.json'
+}
+
+Describe 'Save-AppVersionCache' {
+    BeforeEach {
+        Remove-Item $cachePath -ErrorAction SilentlyContinue
+    }
+
+    It 'records a new version and returns $true' {
+        Save-AppVersionCache -AppName 'Firefox' -Version '143.0.1' -Url 'https://example.test/fx.exe' -Filename 'fx.exe' |
+            Should -BeTrue
+        $cache = Get-Content $cachePath -Raw | ConvertFrom-Json
+        $cache.Apps.Firefox.Version | Should -Be '143.0.1'
+        $cache.Apps.Firefox.Url | Should -Be 'https://example.test/fx.exe'
+        $cache.Apps.Firefox.Filename | Should -Be 'fx.exe'
+        # Raw text, not ConvertFrom-Json: PS7 would coerce the ISO string to [datetime]
+        Get-Content $cachePath -Raw | Should -Match '"UpdatedUtc": "\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z"'
+    }
+
+    It 'skips the write and returns $false when nothing changed' {
+        Save-AppVersionCache -AppName 'Firefox' -Version '143.0.1' -Url 'u' -Filename 'f' | Should -BeTrue
+        Save-AppVersionCache -AppName 'Firefox' -Version '143.0.1' -Url 'u' -Filename 'f' | Should -BeFalse
+    }
+
+    It 'refuses to record the "Latest" placeholder version' {
+        Save-AppVersionCache -AppName 'GoogleDrive' -Version 'Latest' | Should -BeFalse
+        Test-Path $cachePath | Should -BeFalse
+    }
+
+    It 'preserves other apps and keeps keys sorted' {
+        Save-AppVersionCache -AppName 'Firefox' -Version '143.0.1' -Url 'u1' -Filename 'f1' | Should -BeTrue
+        Save-AppVersionCache -AppName 'Audacity' -Version '3.7.8' -Url 'u2' -Filename 'f2' | Should -BeTrue
+        $cache = Get-Content $cachePath -Raw | ConvertFrom-Json
+        $cache.Apps.Firefox.Version | Should -Be '143.0.1'
+        @($cache.Apps.PSObject.Properties.Name) | Should -Be @('Audacity', 'Firefox') -Because 'keys are written sorted for minimal diffs'
+    }
+
+    It 'preserves the _comment header of an existing cache file' {
+        '{ "_comment": "header text", "Apps": {} }' | Set-Content $cachePath
+        Save-AppVersionCache -AppName 'Firefox' -Version '143.0.1' | Should -BeTrue
+        (Get-Content $cachePath -Raw | ConvertFrom-Json)._comment | Should -Be 'header text'
+    }
+
+    It 'writes the cache file without a UTF-8 BOM' {
+        Save-AppVersionCache -AppName 'Firefox' -Version '143.0.1' | Should -BeTrue
+        $bytes = [System.IO.File]::ReadAllBytes($cachePath)
+        $bytes[0] | Should -Not -Be 0xEF
+    }
+}
+
+Describe 'Test-VersionExists' {
+    BeforeAll {
+        $appFolder = Join-Path $TestDrive 'packages\firefox'
+        New-Item -ItemType Directory -Path $appFolder -Force | Out-Null
+        New-Item -ItemType File -Path (Join-Path $appFolder 'Firefox-Setup-143.0.3-de.intunewin') | Out-Null
+    }
+
+    It 'returns $false when the folder does not exist' {
+        Test-VersionExists -AppFolder (Join-Path $TestDrive 'does-not-exist') -NewVersion '1.0' | Should -BeFalse
+    }
+
+    It 'returns $false when the folder has no packages' {
+        $empty = Join-Path $TestDrive 'packages\empty'
+        New-Item -ItemType Directory -Path $empty -Force | Out-Null
+        Test-VersionExists -AppFolder $empty -NewVersion '1.0' | Should -BeFalse
+    }
+
+    It 'returns $true when an equal version already exists' {
+        Test-VersionExists -AppFolder $appFolder -NewVersion '143.0.3' | Should -BeTrue
+    }
+
+    It 'returns $true when a newer version already exists' {
+        Test-VersionExists -AppFolder $appFolder -NewVersion '143.0.1' | Should -BeTrue
+    }
+
+    It 'returns $false when only older versions exist' {
+        Test-VersionExists -AppFolder $appFolder -NewVersion '144.0' | Should -BeFalse
+    }
+}
+
+Describe 'Test-DownloadedFileIntegrity' {
+    BeforeAll {
+        $testFile = Join-Path $TestDrive 'installer.bin'
+        'fixture installer content' | Set-Content $testFile -NoNewline
+        $goodHash = (Get-FileHash -Path $testFile -Algorithm SHA256).Hash
+    }
+
+    It 'returns $false when the file does not exist' {
+        Test-DownloadedFileIntegrity -FilePath (Join-Path $TestDrive 'missing.bin') -ExpectedSha256 $goodHash |
+            Should -BeFalse
+    }
+
+    It 'passes when the SHA-256 hash matches' {
+        Test-DownloadedFileIntegrity -FilePath $testFile -ExpectedSha256 $goodHash | Should -BeTrue
+    }
+
+    It 'normalizes lowercase and whitespace in the expected hash' {
+        Test-DownloadedFileIntegrity -FilePath $testFile -ExpectedSha256 (" $($goodHash.ToLower()) ") | Should -BeTrue
+    }
+
+    It 'fails closed on a SHA-256 mismatch' {
+        Test-DownloadedFileIntegrity -FilePath $testFile -ExpectedSha256 ('0' * 64) | Should -BeFalse
+    }
+
+    It 'fails closed when the expected hash is not valid hex' {
+        Test-DownloadedFileIntegrity -FilePath $testFile -ExpectedSha256 'not-a-hash' | Should -BeFalse
+    }
+
+    It 'fails closed for an unsigned file when signature enforcement is on' {
+        Test-DownloadedFileIntegrity -FilePath $testFile -EnforceSignatureCheck $true | Should -BeFalse
+    }
+
+    It 'passes an unsigned file when signature enforcement is explicitly disabled' {
+        Test-DownloadedFileIntegrity -FilePath $testFile -EnforceSignatureCheck $false | Should -BeTrue
+    }
+}
+
+# These execute against real installer binaries in packages/, which are not in git.
+# They run on a workstation with downloaded packages and are excluded in CI via -ExcludeTag LocalOnly.
+Describe 'Get-InstallerVersion (real installers)' -Tag 'LocalOnly' {
+    BeforeDiscovery {
+        $repoRoot = Split-Path $PSScriptRoot -Parent
+        $msi = Get-ChildItem (Join-Path $repoRoot 'packages\7zip') -Filter '*.msi' -ErrorAction SilentlyContinue | Select-Object -First 1
+        $exe = Get-ChildItem (Join-Path $repoRoot 'packages\gimp') -Filter '*.exe' -ErrorAction SilentlyContinue | Select-Object -First 1
+    }
+
+    It 'extracts the version from an MSI via the WindowsInstaller COM object' -Skip:($null -eq $msi) -ForEach @(@{ InstallerPath = $msi.FullName }) {
+        Get-InstallerVersion -FilePath $InstallerPath | Should -Match '^\d+\.\d+'
+    }
+
+    It 'extracts the version from an EXE via Get-AppLockerFileInformation' -Skip:($null -eq $exe) -ForEach @(@{ InstallerPath = $exe.FullName }) {
+        Get-InstallerVersion -FilePath $InstallerPath | Should -Match '^\d+\.\d+'
+    }
+}

--- a/tests/TenantConfig.Tests.ps1
+++ b/tests/TenantConfig.Tests.ps1
@@ -1,0 +1,111 @@
+#Requires -Version 7.4
+
+# Tests for TenantConfig.ps1: AES-256-GCM secret encryption and config format v3.
+# The script is copied to TestDrive before dot-sourcing so $PSScriptRoot-derived
+# paths (intune-tenants.json) never touch the real repo checkout.
+
+BeforeAll {
+    $repoRoot = Split-Path $PSScriptRoot -Parent
+    $workDir = Join-Path $TestDrive 'tenantconfig'
+    New-Item -ItemType Directory -Path $workDir -Force | Out-Null
+    Copy-Item (Join-Path $repoRoot 'TenantConfig.ps1') $workDir
+    . (Join-Path $workDir 'TenantConfig.ps1')
+    $configPath = Join-Path $workDir 'intune-tenants.json'
+}
+
+AfterAll {
+    # The script initializes session-global cache variables; don't leak them
+    $global:__IntuneCachedMasterKey = $null
+    $global:__IntuneCachedTenantSecrets = @{}
+}
+
+Describe 'Protect-Secret / Unprotect-Secret (AES-256-GCM)' {
+    BeforeAll {
+        $secret = 'my-Cl13nt~S3cret.Value_42'
+        $password = 'correct-horse-battery-staple'
+        $blob = Protect-Secret -PlainText $secret -Password $password
+        $blobBytes = [Convert]::FromBase64String($blob)
+    }
+
+    It 'round-trips a secret with the correct password' {
+        Unprotect-Secret -EncryptedBase64 $blob -Password $password | Should -BeExactly $secret
+    }
+
+    It 'produces the documented blob layout: salt(16) + nonce(12) + tag(16) + ciphertext' {
+        $blobBytes.Length | Should -Be (44 + [Text.Encoding]::UTF8.GetByteCount($secret))
+    }
+
+    It 'uses a fresh salt and nonce per encryption (same input, different blob)' {
+        Protect-Secret -PlainText $secret -Password $password | Should -Not -Be $blob
+    }
+
+    It 'returns $null for a wrong password' {
+        Unprotect-Secret -EncryptedBase64 $blob -Password 'wrong-password' | Should -BeNullOrEmpty
+    }
+
+    It 'returns $null when the ciphertext is tampered with' {
+        $tampered = [byte[]]$blobBytes.Clone()
+        $tampered[44] = $tampered[44] -bxor 1
+        Unprotect-Secret -EncryptedBase64 ([Convert]::ToBase64String($tampered)) -Password $password |
+            Should -BeNullOrEmpty
+    }
+
+    It 'returns $null when the authentication tag is tampered with' {
+        $tampered = [byte[]]$blobBytes.Clone()
+        $tampered[30] = $tampered[30] -bxor 1
+        Unprotect-Secret -EncryptedBase64 ([Convert]::ToBase64String($tampered)) -Password $password |
+            Should -BeNullOrEmpty
+    }
+
+    It 'returns $null for a truncated blob' {
+        Unprotect-Secret -EncryptedBase64 ([Convert]::ToBase64String([byte[]]::new(20))) -Password $password |
+            Should -BeNullOrEmpty
+    }
+
+    It 'returns $null for input that is not valid base64' {
+        Unprotect-Secret -EncryptedBase64 'not-base64!!!' -Password $password | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Tenant config file format v3' {
+    BeforeEach {
+        Remove-Item $configPath -ErrorAction SilentlyContinue
+    }
+
+    It 'returns an in-memory default with version 3 when no file exists' {
+        $config = Read-TenantConfig
+        $config.version | Should -Be 3
+        $config.PSObject.Properties.Name | Should -Contain 'tenants' -Because 'the tenants property must exist even when empty'
+    }
+
+    It 'stamps version 3 when writing a config that has no version property' {
+        Write-TenantConfig -Config ([PSCustomObject]@{ tenants = [PSCustomObject]@{} })
+        (Get-Content $configPath -Raw | ConvertFrom-Json).version | Should -Be 3
+    }
+
+    It 'round-trips a written config through Read-TenantConfig' {
+        Write-TenantConfig -Config (Read-TenantConfig)
+        (Read-TenantConfig).version | Should -Be 3
+    }
+
+    It 'rejects a pre-3.0 config (no version field) with re-add instructions' {
+        '{ "tenants": { "Old": { "tenantId": "x", "clientId": "y", "encryptedSecret": "AAAA" } } }' |
+            Set-Content $configPath
+        { Read-TenantConfig } | Should -Throw -ExpectedMessage '*Add-IntuneTenant*'
+    }
+
+    It 'rejects a config with a newer format version than supported' {
+        '{ "version": 4, "tenants": {} }' | Set-Content $configPath
+        { Read-TenantConfig } | Should -Throw -ExpectedMessage '*newer*'
+    }
+
+    It 'rejects a config file missing the tenants field' {
+        '{ "version": 3 }' | Set-Content $configPath
+        { Read-TenantConfig } | Should -Throw -ExpectedMessage '*tenants*'
+    }
+
+    It 'rejects a config file containing invalid JSON' {
+        'this is { not json' | Set-Content $configPath
+        { Read-TenantConfig } | Should -Throw -ExpectedMessage '*invalid JSON*'
+    }
+}


### PR DESCRIPTION
Groundwork for #8 (and later #9), as discussed: a durable regression suite before the interop refactor, so its "no behavior change" claim is machine-checked.

## What's covered

| File | Coverage |
|---|---|
| `tests/TenantConfig.Tests.ps1` | AES-256-GCM round-trip, blob layout (`salt+nonce+tag+ciphertext`), wrong-password/tamper/truncation → `$null`, config format v3 stamping, pre-3.0/future-format rejection |
| `tests/AppConfig.Tests.ps1` | **Golden-config guard**: pins detection/requirement rule shapes and command lines for one app per detection type — SevenZip (pure MSI), Chrome (hybrid MSI + file detection), Firefox (file), VCRedist (registry existence), GeoGebra (script with version injection). This is the contract the #8 interop refactor must preserve. |
| `tests/SharedFunctions.Tests.ps1` | `Save-AppVersionCache` (writes, no-change skip, key sorting, `_comment`/BOM preservation), `Test-VersionExists`, `Test-DownloadedFileIntegrity` (SHA-256 + signature fail-closed paths) |

## Design notes

- **Sandboxed**: every test file copies the scripts under test to Pester's `$TestDrive` before dot-sourcing, so `$PSScriptRoot`-derived paths (`intune-tenants.json`, `AppVersions.json`, detection scripts) never touch the repo checkout.
- **Real rule builders, mocked metadata**: the golden tests execute the actual `IntuneWin32App` `New-IntuneWin32AppDetectionRule*` / `New-IntuneWin32AppRequirementRule` functions (shapes verified against module 1.5.0); only `Get-IntuneWin32AppMetaData` is mocked, so no `.intunewin` fixture binaries are needed.
- **`LocalOnly` tag**: `Get-InstallerVersion` tests run against real installers in `packages/` (not in git) — they run on a workstation and are excluded in CI.
- **CI**: new `pester` job on `windows-latest` (installs Pester + IntuneWin32App from PSGallery, `-ExcludeTag LocalOnly`). The existing ubuntu parse job stays as the fast first gate.

## Local results

51/51 passing on pwsh 7.6.4 / Pester 6.0.1 / IntuneWin32App 1.5.0, including both `LocalOnly` installer tests (7-Zip MSI via COM, GIMP EXE via AppLocker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)