### PR TITLE
Native Graph assignments and relationship writes (#9 phase 3)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,7 +13,7 @@
 - `TenantConfig.ps1` is dot-sourced by `Deploy-ToIntune.ps1` — `$script:` scoped variables would not persist across runs, which is why `$global:` is used for caching.
 - `AppConfig.ps1` defines all application metadata as a hashtable. New apps are added there.
 - **`IntuneInterop.ps1` is the only file allowed to call `IntuneWin32App` cmdlets** or set the module's global auth state (`$Global:AuthenticationHeader`, `$Global:AccessToken`, `$Global:AccessTokenTenantID`). Everything else uses the `*-Interop*` wrapper functions, which take plain domain values and return Graph-schema shaped hashtables. CI enforces this with an AST-based boundary check in `pwsh-validate.yml`. The boundary exists so the native Graph migration (issue #9) can swap implementations without touching callers — do not add direct module calls outside the boundary.
-- **#9 migration state**: package metadata, detection/requirement rule builders, icons, and the read-only Graph queries (`Get-InteropWin32App`, `Get-InteropAppAssignment`) are native (`Invoke-MgGraphRequest` against `beta`, `-OutputType PSObject`). App creation/upload, assignments, and relationship writes are still module-backed until the later #9 phases land.
+- **#9 migration state**: everything except app creation/upload is native (`Invoke-MgGraphRequest` against `beta`, `-OutputType PSObject`) — package metadata, rule builders, icons, read-only queries, assignments, and relationship writes. `updateRelationships` REPLACES an app's full relationship set, so the supersedence/dependency wrappers read and re-submit the other relationship type (matching the module). Only `Publish-InteropWin32App` (create + chunked upload) is still module-backed.
 
 ## Cryptography Design Decisions
 

--- a/IntuneInterop.ps1
+++ b/IntuneInterop.ps1
@@ -10,8 +10,8 @@
 # Graph calls without changing any caller.
 #
 # Migration state (#9): package metadata, detection/requirement rule builders, icons,
-# and read-only Graph queries are native. App creation/upload, assignments, and
-# relationship writes are still backed by the IntuneWin32App module.
+# read-only Graph queries, assignments, and relationship writes are native. Only app
+# creation/upload (Publish-InteropWin32App) is still backed by the IntuneWin32App module.
 
 $script:InteropModuleName = 'IntuneWin32App'
 
@@ -488,6 +488,87 @@ function Publish-InteropWin32App {
 
 #endregion
 
+#region Native Graph helpers (internal)
+
+function New-InteropAssignmentBody {
+    <#
+    .SYNOPSIS
+    Internal: builds the mobileAppAssignment body shared by the three assignment wrappers
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Intent,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Notification,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Target,
+
+        # The app object (needed for supersededAppCount)
+        [Parameter(Mandatory = $true)]
+        $App,
+
+        [bool]$AutoUpdateSuperseded = $false
+    )
+
+    $body = [ordered]@{
+        '@odata.type' = '#microsoft.graph.mobileAppAssignment'
+        'intent'      = $Intent
+        'source'      = 'direct'
+        'target'      = $Target
+        'settings'    = @{
+            '@odata.type'                  = '#microsoft.graph.win32LobAppAssignmentSettings'
+            'notifications'                = $Notification
+            'restartSettings'              = $null
+            'deliveryOptimizationPriority' = 'notConfigured'
+            'installTimeSettings'          = $null
+        }
+    }
+
+    # The service only accepts autoUpdateSettings when the intent is 'available' and
+    # the app actually supersedes something (matching the module's conditional)
+    if ($Intent -eq 'available' -and $App.supersededAppCount -gt 0) {
+        $body.settings.autoUpdateSettings = @{
+            'autoUpdateSupersededAppsState' = $AutoUpdateSuperseded ? 'enabled' : 'notConfigured'
+        }
+    }
+
+    return $body
+}
+
+function Get-InteropAppRelationship {
+    <#
+    .SYNOPSIS
+    Internal: returns an app's relationship objects, optionally filtered by @odata.type
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$AppId,
+
+        [string]$ODataType
+    )
+
+    $relationships = [System.Collections.Generic.List[object]]::new()
+    $uri = "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps/$AppId/relationships"
+    while ($uri) {
+        $response = Invoke-MgGraphRequest -Method GET -Uri $uri -OutputType PSObject -ErrorAction Stop
+        foreach ($relationship in @($response.value)) {
+            $relationships.Add($relationship)
+        }
+        $uri = $response.'@odata.nextLink'
+    }
+
+    if ($ODataType) {
+        return @($relationships | Where-Object { $_.'@odata.type' -eq $ODataType })
+    }
+    return $relationships
+}
+
+#endregion
+
 #region Assignments
 
 function Get-InteropAppAssignment {
@@ -544,16 +625,29 @@ function Add-InteropAllUsersAssignment {
 
         [string]$Notification = 'showAll',
 
-        # Request "auto update superseded apps" on this assignment. The module only
-        # writes the setting when the intent is 'available'.
+        # Request "auto update superseded apps" on this assignment. Only written when
+        # the intent is 'available' and the app supersedes something.
         [bool]$AutoUpdateSuperseded = $false
     )
 
-    $params = @{ ID = $AppId; Intent = $Intent; Notification = $Notification }
-    if ($AutoUpdateSuperseded) {
-        $params['AutoUpdateSupersededApps'] = 'enabled'
+    try {
+        $app = Invoke-MgGraphRequest -Method GET -Uri "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps/$AppId" -OutputType PSObject -ErrorAction Stop
+
+        $target = @{
+            '@odata.type'                                = '#microsoft.graph.allLicensedUsersAssignmentTarget'
+            'deviceAndAppManagementAssignmentFilterId'   = $null
+            'deviceAndAppManagementAssignmentFilterType' = 'none'
+        }
+        $body = New-InteropAssignmentBody -Intent $Intent -Notification $Notification -Target $target -App $app -AutoUpdateSuperseded $AutoUpdateSuperseded
+
+        return Invoke-MgGraphRequest -Method POST -Uri "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps/$AppId/assignments" -Body ($body | ConvertTo-Json -Depth 10) -ContentType 'application/json' -OutputType PSObject -ErrorAction Stop
     }
-    return Add-IntuneWin32AppAssignmentAllUsers @params
+    catch {
+        # Warn-and-return-$null matches the module: callers report "assignment was
+        # NOT created" and continue with the rest of the deployment
+        Write-Warning "An error occurred while creating the All Users assignment for app '$AppId': $($_.Exception.Message)"
+        return $null
+    }
 }
 
 function Add-InteropAllDevicesAssignment {
@@ -571,7 +665,22 @@ function Add-InteropAllDevicesAssignment {
         [string]$Notification = 'showAll'
     )
 
-    return Add-IntuneWin32AppAssignmentAllDevices -ID $AppId -Intent $Intent -Notification $Notification
+    try {
+        $app = Invoke-MgGraphRequest -Method GET -Uri "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps/$AppId" -OutputType PSObject -ErrorAction Stop
+
+        $target = @{
+            '@odata.type'                                = '#microsoft.graph.allDevicesAssignmentTarget'
+            'deviceAndAppManagementAssignmentFilterId'   = $null
+            'deviceAndAppManagementAssignmentFilterType' = 'none'
+        }
+        $body = New-InteropAssignmentBody -Intent $Intent -Notification $Notification -Target $target -App $app
+
+        return Invoke-MgGraphRequest -Method POST -Uri "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps/$AppId/assignments" -Body ($body | ConvertTo-Json -Depth 10) -ContentType 'application/json' -OutputType PSObject -ErrorAction Stop
+    }
+    catch {
+        Write-Warning "An error occurred while creating the All Devices assignment for app '$AppId': $($_.Exception.Message)"
+        return $null
+    }
 }
 
 function Add-InteropGroupAssignment {
@@ -591,15 +700,27 @@ function Add-InteropGroupAssignment {
 
         [string]$Notification = 'showAll',
 
-        # Only valid with intent 'available' - the module rejects it outright otherwise
+        # Only written when the intent is 'available' and the app supersedes something
         [bool]$AutoUpdateSuperseded = $false
     )
 
-    $params = @{ Include = $true; ID = $AppId; GroupID = $GroupId; Intent = $Intent; Notification = $Notification }
-    if ($AutoUpdateSuperseded -and $Intent -eq 'available') {
-        $params['AutoUpdateSupersededApps'] = 'enabled'
+    try {
+        $app = Invoke-MgGraphRequest -Method GET -Uri "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps/$AppId" -OutputType PSObject -ErrorAction Stop
+
+        $target = @{
+            '@odata.type'                                = '#microsoft.graph.groupAssignmentTarget'
+            'deviceAndAppManagementAssignmentFilterId'   = $null
+            'deviceAndAppManagementAssignmentFilterType' = 'none'
+            'groupId'                                    = $GroupId
+        }
+        $body = New-InteropAssignmentBody -Intent $Intent -Notification $Notification -Target $target -App $app -AutoUpdateSuperseded $AutoUpdateSuperseded
+
+        return Invoke-MgGraphRequest -Method POST -Uri "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps/$AppId/assignments" -Body ($body | ConvertTo-Json -Depth 10) -ContentType 'application/json' -OutputType PSObject -ErrorAction Stop
     }
-    return Add-IntuneWin32AppAssignmentGroup @params
+    catch {
+        Write-Warning "An error occurred while creating the group assignment for app '$AppId': $($_.Exception.Message)"
+        return $null
+    }
 }
 
 #endregion
@@ -623,8 +744,25 @@ function Add-InteropSupersedence {
         [string]$SupersedenceType = 'Update'
     )
 
-    $supersedence = New-IntuneWin32AppSupersedence -ID $SupersededAppId -SupersedenceType $SupersedenceType
-    Add-IntuneWin32AppSupersedence -ID $AppId -Supersedence $supersedence -Verbose
+    if ($AppId -eq $SupersededAppId) {
+        Write-Warning "A Win32 app cannot supersede itself (app ID '$AppId')"
+        return
+    }
+
+    $supersedence = [ordered]@{
+        '@odata.type'      = '#microsoft.graph.mobileAppSupersedence'
+        'supersedenceType' = $SupersedenceType.ToLower()
+        'targetId'         = $SupersededAppId
+    }
+
+    # updateRelationships REPLACES the app's entire relationship set, so existing
+    # dependency relationships must be read and re-submitted alongside the new
+    # supersedence (which itself replaces any previous supersedence - matching the
+    # module's behavior)
+    $dependencies = @(Get-InteropAppRelationship -AppId $AppId -ODataType '#microsoft.graph.mobileAppDependency')
+
+    $body = [ordered]@{ 'relationships' = @(@($supersedence) + $dependencies) }
+    $null = Invoke-MgGraphRequest -Method POST -Uri "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps/$AppId/updateRelationships" -Body ($body | ConvertTo-Json -Depth 10) -ContentType 'application/json' -ErrorAction Stop
 }
 
 function Add-InteropDependency {
@@ -643,10 +781,27 @@ function Add-InteropDependency {
         [string]$DependencyType = 'AutoInstall'
     )
 
-    $dependencies = foreach ($dependencyAppId in $DependencyAppIds) {
-        New-IntuneWin32AppDependency -ID $dependencyAppId -DependencyType $DependencyType
+    if ($AppId -in $DependencyAppIds) {
+        Write-Warning "A Win32 app cannot depend on itself (app ID '$AppId')"
+        return
     }
-    Add-IntuneWin32AppDependency -ID $AppId -Dependency @($dependencies) -Verbose
+
+    $dependencies = foreach ($dependencyAppId in $DependencyAppIds) {
+        [ordered]@{
+            '@odata.type'    = '#microsoft.graph.mobileAppDependency'
+            'dependencyType' = $DependencyType
+            'targetId'       = $dependencyAppId
+        }
+    }
+
+    # updateRelationships REPLACES the app's entire relationship set, so existing
+    # supersedence relationships must be read and re-submitted alongside the new
+    # dependencies (which themselves replace any previous dependencies - matching
+    # the module's behavior)
+    $supersedences = @(Get-InteropAppRelationship -AppId $AppId -ODataType '#microsoft.graph.mobileAppSupersedence')
+
+    $body = [ordered]@{ 'relationships' = @(@($dependencies) + $supersedences) }
+    $null = Invoke-MgGraphRequest -Method POST -Uri "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps/$AppId/updateRelationships" -Body ($body | ConvertTo-Json -Depth 10) -ContentType 'application/json' -ErrorAction Stop
 }
 
 #endregion

--- a/IntuneInterop.ps1
+++ b/IntuneInterop.ps1
@@ -751,7 +751,7 @@ function Add-InteropSupersedence {
 
     $supersedence = [ordered]@{
         '@odata.type'      = '#microsoft.graph.mobileAppSupersedence'
-        'supersedenceType' = $SupersedenceType.ToLower()
+        'supersedenceType' = $SupersedenceType.ToLowerInvariant()
         'targetId'         = $SupersededAppId
     }
 

--- a/tests/IntuneInterop.Tests.ps1
+++ b/tests/IntuneInterop.Tests.ps1
@@ -17,7 +17,7 @@ BeforeAll {
     # wrappers pass (-ErrorAction).
     function Invoke-MgGraphRequest {
         [CmdletBinding()]
-        param($Method, $Uri, $OutputType)
+        param($Method, $Uri, $OutputType, $Body, $ContentType)
         throw 'stub was not mocked'
     }
 
@@ -190,5 +190,155 @@ Describe 'Get-InteropAppAssignment (native Graph read + normalization)' {
     It 'returns an empty array when the request fails' {
         Mock Invoke-MgGraphRequest { throw 'Graph unavailable' }
         @(Get-InteropAppAssignment -AppId 'app-1').Count | Should -Be 0
+    }
+}
+
+Describe 'Add-Interop*Assignment (native Graph writes)' {
+    BeforeAll {
+        # GET returns the app (supersededAppCount drives autoUpdateSettings);
+        # POST returns the created assignment
+        Mock Invoke-MgGraphRequest {
+            if ($Method -eq 'GET') {
+                [PSCustomObject]@{ id = 'app-1'; supersededAppCount = 1 }
+            }
+            else {
+                [PSCustomObject]@{ id = 'assignment-1' }
+            }
+        }
+    }
+
+    It 'posts an All Users assignment with the win32LobApp settings shape' {
+        $result = Add-InteropAllUsersAssignment -AppId 'app-1' -Intent 'available' -Notification 'showAll'
+        $result.id | Should -Be 'assignment-1'
+        Should -Invoke Invoke-MgGraphRequest -ParameterFilter {
+            if ($Method -ne 'POST') { return $false }
+            $parsed = $Body | ConvertFrom-Json
+            $parsed.'@odata.type' -eq '#microsoft.graph.mobileAppAssignment' -and
+            $parsed.intent -eq 'available' -and
+            $parsed.source -eq 'direct' -and
+            $parsed.target.'@odata.type' -eq '#microsoft.graph.allLicensedUsersAssignmentTarget' -and
+            $parsed.settings.'@odata.type' -eq '#microsoft.graph.win32LobAppAssignmentSettings' -and
+            $parsed.settings.notifications -eq 'showAll'
+        } -Times 1 -Exactly
+    }
+
+    It 'writes autoUpdateSettings enabled for available intent on a superseding app' {
+        $null = Add-InteropAllUsersAssignment -AppId 'app-1' -Intent 'available' -AutoUpdateSuperseded $true
+        Should -Invoke Invoke-MgGraphRequest -ParameterFilter {
+            $Method -eq 'POST' -and
+            ($Body | ConvertFrom-Json).settings.autoUpdateSettings.autoUpdateSupersededAppsState -eq 'enabled'
+        } -Times 1 -Exactly
+    }
+
+    It 'omits autoUpdateSettings when the app supersedes nothing' {
+        Mock Invoke-MgGraphRequest {
+            if ($Method -eq 'GET') { [PSCustomObject]@{ id = 'app-2'; supersededAppCount = 0 } }
+            else { [PSCustomObject]@{ id = 'assignment-2' } }
+        }
+        $null = Add-InteropAllUsersAssignment -AppId 'app-2' -Intent 'available' -AutoUpdateSuperseded $true
+        Should -Invoke Invoke-MgGraphRequest -ParameterFilter {
+            $Method -eq 'POST' -and $null -eq ($Body | ConvertFrom-Json).settings.autoUpdateSettings
+        } -Times 1 -Exactly
+    }
+
+    It 'targets All Devices with the required intent and no autoUpdateSettings' {
+        $null = Add-InteropAllDevicesAssignment -AppId 'app-1' -Intent 'required'
+        Should -Invoke Invoke-MgGraphRequest -ParameterFilter {
+            if ($Method -ne 'POST') { return $false }
+            $parsed = $Body | ConvertFrom-Json
+            $parsed.target.'@odata.type' -eq '#microsoft.graph.allDevicesAssignmentTarget' -and
+            $parsed.intent -eq 'required' -and
+            $null -eq $parsed.settings.autoUpdateSettings
+        } -Times 1 -Exactly
+    }
+
+    It 'targets the group and carries the groupId' {
+        $null = Add-InteropGroupAssignment -AppId 'app-1' -GroupId 'g-9' -Intent 'available'
+        Should -Invoke Invoke-MgGraphRequest -ParameterFilter {
+            if ($Method -ne 'POST') { return $false }
+            $parsed = $Body | ConvertFrom-Json
+            $parsed.target.'@odata.type' -eq '#microsoft.graph.groupAssignmentTarget' -and
+            $parsed.target.groupId -eq 'g-9'
+        } -Times 1 -Exactly
+    }
+
+    It 'warns and returns $null when the POST fails' {
+        Mock Invoke-MgGraphRequest {
+            if ($Method -eq 'GET') { [PSCustomObject]@{ id = 'app-1'; supersededAppCount = 0 } }
+            else { throw 'BadRequest: The MobileApp Assignment already exists' }
+        }
+        Add-InteropAllUsersAssignment -AppId 'app-1' -Intent 'available' -WarningAction SilentlyContinue |
+            Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Add-InteropSupersedence (native updateRelationships)' {
+    It 'merges the new supersedence with existing dependencies, replacing old supersedence' {
+        Mock Invoke-MgGraphRequest {
+            if ($Method -eq 'GET') {
+                [PSCustomObject]@{
+                    value = @(
+                        [PSCustomObject]@{ '@odata.type' = '#microsoft.graph.mobileAppDependency'; dependencyType = 'autoInstall'; targetId = 'dep-1' },
+                        [PSCustomObject]@{ '@odata.type' = '#microsoft.graph.mobileAppSupersedence'; supersedenceType = 'update'; targetId = 'ancient-app' }
+                    )
+                }
+            }
+        }
+
+        Add-InteropSupersedence -AppId 'new-app' -SupersededAppId 'old-app' -SupersedenceType 'Replace'
+
+        Should -Invoke Invoke-MgGraphRequest -ParameterFilter {
+            if ($Method -ne 'POST') { return $false }
+            $rels = @(($Body | ConvertFrom-Json).relationships)
+            $supersedences = @($rels | Where-Object { $_.'@odata.type' -eq '#microsoft.graph.mobileAppSupersedence' })
+            $dependencies = @($rels | Where-Object { $_.'@odata.type' -eq '#microsoft.graph.mobileAppDependency' })
+            $rels.Count -eq 2 -and
+            $supersedences.Count -eq 1 -and
+            $supersedences[0].targetId -eq 'old-app' -and
+            $supersedences[0].supersedenceType -eq 'replace' -and
+            $dependencies[0].targetId -eq 'dep-1'
+        } -Times 1 -Exactly
+    }
+
+    It 'refuses self-supersedence without calling Graph' {
+        Mock Invoke-MgGraphRequest { }
+        Add-InteropSupersedence -AppId 'a' -SupersededAppId 'a' -WarningAction SilentlyContinue
+        Should -Invoke Invoke-MgGraphRequest -Times 0 -Exactly
+    }
+}
+
+Describe 'Add-InteropDependency (native updateRelationships)' {
+    It 'merges new dependencies with existing supersedence, replacing old dependencies' {
+        Mock Invoke-MgGraphRequest {
+            if ($Method -eq 'GET') {
+                [PSCustomObject]@{
+                    value = @(
+                        [PSCustomObject]@{ '@odata.type' = '#microsoft.graph.mobileAppSupersedence'; supersedenceType = 'update'; targetId = 'old-version' },
+                        [PSCustomObject]@{ '@odata.type' = '#microsoft.graph.mobileAppDependency'; dependencyType = 'autoInstall'; targetId = 'stale-dep' }
+                    )
+                }
+            }
+        }
+
+        Add-InteropDependency -AppId 'app' -DependencyAppIds @('dep-a', 'dep-b')
+
+        Should -Invoke Invoke-MgGraphRequest -ParameterFilter {
+            if ($Method -ne 'POST') { return $false }
+            $rels = @(($Body | ConvertFrom-Json).relationships)
+            $dependencies = @($rels | Where-Object { $_.'@odata.type' -eq '#microsoft.graph.mobileAppDependency' })
+            $supersedences = @($rels | Where-Object { $_.'@odata.type' -eq '#microsoft.graph.mobileAppSupersedence' })
+            $rels.Count -eq 3 -and
+            $dependencies.Count -eq 2 -and
+            ($dependencies.targetId -contains 'dep-a') -and
+            ($dependencies.targetId -contains 'dep-b') -and
+            ($dependencies.targetId -notcontains 'stale-dep') -and
+            $supersedences[0].targetId -eq 'old-version'
+        } -Times 1 -Exactly
+    }
+
+    It 'refuses self-dependency without calling Graph' {
+        Mock Invoke-MgGraphRequest { }
+        Add-InteropDependency -AppId 'a' -DependencyAppIds @('b', 'a') -WarningAction SilentlyContinue
+        Should -Invoke Invoke-MgGraphRequest -Times 0 -Exactly
     }
 }


### PR DESCRIPTION
Phase 3 of #9, built on the merged phases 1+2 (#20). After this, **only `Publish-InteropWin32App` (app creation + chunked content upload) remains module-backed** — that's phase 4.

## Assignments

`Add-InteropAllUsersAssignment` / `AllDevices` / `Group` now POST `…/mobileApps/{id}/assignments` natively with the exact body the module constructed (verified against the 1.5.0 source):

- `mobileAppAssignment` with `source: direct`, target type + `deviceAndAppManagementAssignmentFilterId: null` / `FilterType: 'none'`, and `win32LobAppAssignmentSettings` (notifications, null restart/installTime settings, `deliveryOptimizationPriority: notConfigured`).
- **The subtle one**: `autoUpdateSettings` is only written when intent is `available` **and** the app's `supersededAppCount > 0` — which is why each assignment does a GET of the app first, exactly like the module did. State is `enabled` when requested, otherwise `notConfigured`.
- POST failures warn and return `$null`, preserving Deploy-ToIntune's "assignment was NOT created" reporting path unchanged.

## Relationships

`Add-InteropSupersedence` / `Add-InteropDependency` POST `…/updateRelationships`, which **replaces the app's entire relationship set**. The module's asymmetric merge is reproduced exactly:

- Writing supersedence re-submits existing **dependencies** (and replaces any previous supersedence).
- Writing dependencies re-submits existing **supersedence** (and replaces any previous dependencies).
- `supersedenceType` lowercased, `dependencyType` as-is, self-reference guarded (warning, no Graph call) — all module parity.

**One deliberate behavior change**: the module swallowed relationship POST failures as warnings, so Deploy-ToIntune printed `[OK] Supersedence configured` even when the write had failed. The native implementation lets the failure propagate to Deploy's existing `try/catch`, which reports `[Err] Failed to set supersedence` accurately.

## Tests

10 new tests pin the assignment POST bodies (settings shape, `autoUpdateSettings` conditionality per intent/superseded-count, group `groupId`, failure path) and both relationship merge directions (existing-other-type preserved, same-type replaced, self-reference refusal). 75/75 passing, boundary + parse checks clean, `-ShowPlan` unchanged.

## Pre-merge live smoke (needs you)

Two runs against MZ:
1. `.\Deploy-ToIntune.ps1 -TenantName "MZ"` — reconcile; everything should report "already assigned/exists".
2. A versioned deploy with supersedence — e.g. after packaging a newer Firefox: `.\Deploy-ToIntune.ps1 -TenantName "MZ" -AppName "Firefox"` — then verify in the portal that the new app has the supersedence relationship, the auto-update flag on the All Users assignment, and both assignments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)