### PR TITLE
Refactor: bring every function under the cognitive complexity limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ packages/Schuelerkopierer/*
 tmp/
 sccm-management/
 user-device-management/
+
+.mcp.json
+.env

--- a/AppCleanup.ps1
+++ b/AppCleanup.ps1
@@ -13,6 +13,108 @@
 
 . (Join-Path $PSScriptRoot "AppInventory.ps1")
 
+# Why a delete candidate must NOT be deleted - $null when it may be. Every rule here is already
+# enforced by the retention evaluator or the analysis; they are re-checked so a future change
+# upstream cannot silently widen the deletions.
+function Get-AppCleanupSkipReason {
+    param(
+        # One Analysis family
+        [Parameter(Mandatory = $true)]
+        $Family,
+
+        # The candidate's inventory record ($null when the analysis has none)
+        [AllowNull()]
+        $Record
+    )
+
+    if (-not $Family.InPlan) { return "family '$($Family.Family)' is not in the tenant's deployment plan" }
+    if ($null -eq $Record) { return 'candidate has no inventory record' }
+    if ($Record.Retention.Action -ne 'Delete') { return "retention verdict is '$($Record.Retention.Action)', not 'Delete'" }
+    if ($Record.RelationshipsUnavailable) { return 'relationships could not be read - may be a dependency target' }
+    if (@($Record.DependencyOf).Count -gt 0) { return 'dependency target' }
+    if ($Family.Newest -and $Record.Id -eq $Family.Newest.Id) { return 'newest version' }
+    if ($Record.Retention.Rank -le $Family.Policy.KeepNewest) { return "within the newest $($Family.Policy.KeepNewest) versions" }
+
+    return $null
+}
+
+# One plan entry for one delete candidate. Everything the inventory record answers is $null when
+# there is no record; AssignmentCount and InstalledDeviceCount are also $null ($null = unknown)
+# when the tenant read for that record failed. A Reason is only carried by skipped entries.
+function New-AppCleanupEntry {
+    param(
+        [Parameter(Mandatory = $true)]
+        $Family,
+
+        # One DeleteCandidate of that family
+        [Parameter(Mandatory = $true)]
+        $Candidate,
+
+        [AllowNull()]
+        $Record,
+
+        [AllowNull()]
+        [string]$Reason
+    )
+
+    $entry = [ordered]@{
+        Id                   = $Candidate.Id
+        Family               = $Family.Family
+        DisplayName          = $Candidate.DisplayName
+        DisplayVersion       = if ($Record) { $Record.DisplayVersion } else { $Candidate.Version }
+        Version              = $Candidate.Version
+        Rank                 = $Record.Retention.Rank                                     # $null without a record
+        AgeWeeks             = $Candidate.AgeWeeks
+        SupersededWeeks      = $Candidate.SupersededWeeks
+        CreatedDateTime      = $Record.CreatedDateTime
+        AssignmentCount      = if ($Record -and -not $Record.AssignmentsUnavailable) { @($Record.Assignments).Count } else { $null }
+        SupersededBy         = if ($Record) { @($Record.SupersededBy | ForEach-Object { $_.TargetDisplayName }) } else { @() }
+        InstalledDeviceCount = if ($Record -and $Record.InstallSummary) { $Record.InstallSummary.installedDeviceCount } else { $null }
+    }
+
+    if ($Reason) { $entry.Reason = $Reason }
+
+    return [PSCustomObject]$entry
+}
+
+# The plan for one family: its deletions (oldest version first) and every delete candidate that is
+# not deleted, with the reason why.
+function Get-AppCleanupFamilyPlan {
+    param(
+        [Parameter(Mandatory = $true)]
+        $Family,
+
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [array]$Records
+    )
+
+    $members = @($Records | Where-Object { $_.Family -eq $Family.Family })
+    $deletions = [System.Collections.Generic.List[object]]::new()
+    $skipped = [System.Collections.Generic.List[object]]::new()
+
+    # DeleteCandidates are already ordered oldest first (Select-AppRetentionDeleteCandidates)
+    foreach ($candidate in @($Family.DeleteCandidates)) {
+        $record = $members | Where-Object Id -eq $candidate.Id | Select-Object -First 1
+        $reason = Get-AppCleanupSkipReason -Family $Family -Record $record
+        $entry = New-AppCleanupEntry -Family $Family -Candidate $candidate -Record $record -Reason $reason
+
+        if ($reason) { $skipped.Add($entry) } else { $deletions.Add($entry) }
+    }
+
+    return [PSCustomObject]@{
+        Family                = $Family.Family
+        InPlan                = $Family.InPlan
+        Policy                = $Family.Policy
+        VersionCount          = $Family.VersionCount
+        KeepCount             = $Family.KeepCount
+        ReviewCount           = $Family.ReviewCount
+        Deletions             = @($deletions)
+        Skipped               = @($skipped)
+        RemainingAfterCleanup = $Family.VersionCount - $deletions.Count
+    }
+}
+
 function Get-AppCleanupPlan {
     <#
     .SYNOPSIS
@@ -35,70 +137,17 @@ function Get-AppCleanupPlan {
     )
 
     $families = [System.Collections.Generic.List[object]]::new()
-    $deletions = [System.Collections.Generic.List[object]]::new()
 
     foreach ($family in ($Analysis.Families | Sort-Object Family)) {
-        $members = @($Records | Where-Object { $_.Family -eq $family.Family })
-        $familyDeletions = [System.Collections.Generic.List[object]]::new()
-        $skipped = [System.Collections.Generic.List[object]]::new()
-
-        # DeleteCandidates are already ordered oldest first (Select-AppRetentionDeleteCandidates)
-        foreach ($candidate in @($family.DeleteCandidates)) {
-            $record = $members | Where-Object Id -eq $candidate.Id | Select-Object -First 1
-
-            # Every rule below is already enforced by the evaluator or the analysis; they are
-            # re-checked here so a future change upstream cannot silently widen the deletions.
-            $reason = $null
-            if (-not $family.InPlan) { $reason = "family '$($family.Family)' is not in the tenant's deployment plan" }
-            elseif ($null -eq $record) { $reason = 'candidate has no inventory record' }
-            elseif ($record.Retention.Action -ne 'Delete') { $reason = "retention verdict is '$($record.Retention.Action)', not 'Delete'" }
-            elseif ($record.RelationshipsUnavailable) { $reason = 'relationships could not be read - may be a dependency target' }
-            elseif (@($record.DependencyOf).Count -gt 0) { $reason = 'dependency target' }
-            elseif ($family.Newest -and $record.Id -eq $family.Newest.Id) { $reason = 'newest version' }
-            elseif ($record.Retention.Rank -le $family.Policy.KeepNewest) { $reason = "within the newest $($family.Policy.KeepNewest) versions" }
-
-            $entry = [ordered]@{
-                Id                   = $candidate.Id
-                Family               = $family.Family
-                DisplayName          = $candidate.DisplayName
-                DisplayVersion       = if ($record) { $record.DisplayVersion } else { $candidate.Version }
-                Version              = $candidate.Version
-                Rank                 = if ($record) { $record.Retention.Rank } else { $null }
-                AgeWeeks             = $candidate.AgeWeeks
-                SupersededWeeks      = $candidate.SupersededWeeks
-                CreatedDateTime      = if ($record) { $record.CreatedDateTime } else { $null }
-                AssignmentCount      = if ($record -and -not $record.AssignmentsUnavailable) { @($record.Assignments).Count } else { $null }   # $null = unknown
-                SupersededBy         = if ($record) { @($record.SupersededBy | ForEach-Object { $_.TargetDisplayName }) } else { @() }
-                InstalledDeviceCount = if ($record -and $record.InstallSummary) { $record.InstallSummary.installedDeviceCount } else { $null }
-                Reason               = $reason
-            }
-
-            if ($reason) {
-                $skipped.Add([PSCustomObject]$entry)
-            }
-            else {
-                $entry.Remove('Reason')
-                $familyDeletions.Add([PSCustomObject]$entry)
-                $deletions.Add([PSCustomObject]$entry)
-            }
-        }
-
-        $families.Add([PSCustomObject]@{
-            Family                = $family.Family
-            InPlan                = $family.InPlan
-            Policy                = $family.Policy
-            VersionCount          = $family.VersionCount
-            KeepCount             = $family.KeepCount
-            ReviewCount           = $family.ReviewCount
-            Deletions             = @($familyDeletions)
-            Skipped               = @($skipped)
-            RemainingAfterCleanup = $family.VersionCount - $familyDeletions.Count
-        })
+        $families.Add((Get-AppCleanupFamilyPlan -Family $family -Records $Records))
     }
+
+    # Execution order: family by name (the loop above), oldest version first (within each family)
+    $deletions = @($families | ForEach-Object { $_.Deletions })
 
     return [PSCustomObject]@{
         Families      = @($families)
-        Deletions     = @($deletions)
+        Deletions     = $deletions
         DeletionCount = $deletions.Count
         SkippedCount  = ($families | ForEach-Object { $_.Skipped.Count } | Measure-Object -Sum).Sum ?? 0
     }

--- a/AppConfig.ps1
+++ b/AppConfig.ps1
@@ -489,6 +489,56 @@ $script:AppConfigurations = @{
     }
 }
 
+# A download-URL allowlist entry is only usable when it is a non-empty https:// prefix ending in
+# '/' and without surrounding whitespace. A blank prefix would match every URL; whitespace padding
+# or a non-HTTPS scheme means the prefix can never match at runtime (mis-pasted allowlist); and
+# without a trailing '/' a prefix match could cross an authority boundary ("https://vendor.example"
+# would also match "https://vendor.example.evil.com/").
+# Case-insensitive like the runtime check in Get-WingetInstallerInfo.
+function Test-AppConfigUrlPrefix {
+    param($Prefix)
+
+    if ([string]::IsNullOrWhiteSpace($Prefix)) { return $false }
+    if ("$Prefix" -ne "$Prefix".Trim()) { return $false }
+    if (-not "$Prefix".StartsWith('https://', [System.StringComparison]::OrdinalIgnoreCase)) { return $false }
+
+    return "$Prefix".EndsWith('/')
+}
+
+# The policy violations of one app configuration (see Get-AppConfigPolicyViolation).
+function Get-AppConfigAppViolation {
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$Name,
+
+        [Parameter(Mandatory=$true)]
+        $Configuration
+    )
+
+    $violations = @()
+
+    if ($Configuration.AllowUnsignedInstaller -and -not ($Configuration.WingetPackageId -or $Configuration.ExpectedSha256)) {
+        $violations += "${Name}: AllowUnsignedInstaller requires WingetPackageId or ExpectedSha256 - downloads must stay verifiable"
+    }
+
+    if (-not $Configuration.WingetPackageId) {
+        return $violations
+    }
+
+    if (-not $Configuration.AllowedDownloadUrlPrefixes) {
+        return $violations + "${Name}: WingetPackageId requires AllowedDownloadUrlPrefixes to pin where installers may be fetched from"
+    }
+
+    # One message per app, not per bad entry - the allowlist is fixed as a whole
+    foreach ($prefix in $Configuration.AllowedDownloadUrlPrefixes) {
+        if (-not (Test-AppConfigUrlPrefix -Prefix $prefix)) {
+            return $violations + "${Name}: every AllowedDownloadUrlPrefixes entry must be a non-empty https:// prefix ending in '/' and without surrounding whitespace (found '$prefix')"
+        }
+    }
+
+    return $violations
+}
+
 # Download-integrity policy: every app must anchor the integrity of its downloads somewhere.
 # Signed installers are covered by the default Authenticode check (plus ExpectedPublisher);
 # an app that opts out of the signature check (AllowUnsignedInstaller) must instead be
@@ -502,31 +552,7 @@ function Get-AppConfigPolicyViolation {
 
     $violations = @()
     foreach ($name in ($Configurations.Keys | Sort-Object)) {
-        $cfg = $Configurations[$name]
-        if ($cfg.AllowUnsignedInstaller -and -not ($cfg.WingetPackageId -or $cfg.ExpectedSha256)) {
-            $violations += "${name}: AllowUnsignedInstaller requires WingetPackageId or ExpectedSha256 - downloads must stay verifiable"
-        }
-        if ($cfg.WingetPackageId) {
-            if (-not $cfg.AllowedDownloadUrlPrefixes) {
-                $violations += "${name}: WingetPackageId requires AllowedDownloadUrlPrefixes to pin where installers may be fetched from"
-            }
-            else {
-                foreach ($prefix in $cfg.AllowedDownloadUrlPrefixes) {
-                    # A blank prefix would match every URL; whitespace padding or a non-HTTPS
-                    # scheme means the prefix can never match at runtime (mis-pasted allowlist);
-                    # and without a trailing '/' a prefix match could cross an authority boundary
-                    # ("https://vendor.example" would also match "https://vendor.example.evil.com/").
-                    # Case-insensitive like the runtime check in Get-WingetInstallerInfo.
-                    if ([string]::IsNullOrWhiteSpace($prefix) -or
-                        "$prefix" -ne "$prefix".Trim() -or
-                        -not "$prefix".StartsWith('https://', [System.StringComparison]::OrdinalIgnoreCase) -or
-                        -not "$prefix".EndsWith('/')) {
-                        $violations += "${name}: every AllowedDownloadUrlPrefixes entry must be a non-empty https:// prefix ending in '/' and without surrounding whitespace (found '$prefix')"
-                        break
-                    }
-                }
-            }
-        }
+        $violations += @(Get-AppConfigAppViolation -Name $name -Configuration $Configurations[$name])
     }
     return $violations
 }
@@ -542,6 +568,56 @@ if ($configPolicyViolations.Count -gt 0) {
 # Also consumed by Save-AppVersionCache in SharedFunctions.ps1.
 $script:AppVersionCachePath = Join-Path $PSScriptRoot "AppVersions.json"
 
+# The parsed version cache, or $null when there is none or it cannot be read.
+function Read-AppVersionCache {
+    param([string]$Path)
+
+    if (-not (Test-Path $Path)) {
+        return $null
+    }
+
+    try {
+        return Get-Content -Path $Path -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+    }
+    catch {
+        Write-Warning "Ignoring unreadable version cache '$Path': $($_.Exception.Message)"
+        return $null
+    }
+}
+
+# $true when the seed in this file is demonstrably newer than the cached version - the only case
+# in which the cache does not win. Unparseable on either side means the cache wins.
+function Test-AppConfigSeedIsNewer {
+    param($SeedVersion, $CachedVersion)
+
+    if (-not $SeedVersion) { return $false }
+
+    $seedParsed = $null
+    $cachedParsed = $null
+    if (-not [version]::TryParse($SeedVersion, [ref]$seedParsed)) { return $false }
+    if (-not [version]::TryParse($CachedVersion, [ref]$cachedParsed)) { return $false }
+
+    return $seedParsed -gt $cachedParsed
+}
+
+# Overlays one cache entry onto its (by-reference) app configuration.
+function Update-AppConfigFromCache {
+    param($AppConfig, $Cached)
+
+    if ([string]::IsNullOrWhiteSpace($Cached.Version)) {
+        return
+    }
+    if (Test-AppConfigSeedIsNewer -SeedVersion $AppConfig.FallbackVersion -CachedVersion $Cached.Version) {
+        return
+    }
+
+    $AppConfig.FallbackVersion = $Cached.Version
+    if ($Cached.Url) { $AppConfig.FallbackUrl = $Cached.Url }
+    # Recorded alongside the URL because FilenameTemplate cannot always reproduce the real
+    # asset name (7-Zip's 7z2602-x64.msi, Inkscape's dated builds, Next-Exam's build stamps)
+    if ($Cached.Filename) { $AppConfig.FallbackFilename = $Cached.Filename }
+}
+
 # Overlay the last successfully downloaded version/URL/filename onto the seed fallbacks defined
 # above, so FallbackVersion and FallbackUrl stay current without anyone editing this file.
 #
@@ -550,52 +626,16 @@ $script:AppVersionCachePath = Join-Path $PSScriptRoot "AppVersions.json"
 # which means a stale cache can never drag a freshly pulled AppConfig.ps1 backwards - that is what
 # makes it safe to auto-resolve AppVersions.json merges in favour of the local copy (.gitattributes).
 function Import-AppVersionCache {
-    if (-not (Test-Path $script:AppVersionCachePath)) {
-        return
-    }
-
-    try {
-        $cache = Get-Content -Path $script:AppVersionCachePath -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
-    }
-    catch {
-        Write-Warning "Ignoring unreadable version cache '$script:AppVersionCachePath': $($_.Exception.Message)"
-        return
-    }
-
-    if (-not $cache.Apps) {
+    $cache = Read-AppVersionCache -Path $script:AppVersionCachePath
+    if (-not $cache -or -not $cache.Apps) {
         return
     }
 
     foreach ($entry in $cache.Apps.PSObject.Properties) {
         # Silently ignore apps the cache knows about but this config no longer defines
-        if (-not $script:AppConfigurations.ContainsKey($entry.Name)) {
-            continue
+        if ($script:AppConfigurations.ContainsKey($entry.Name)) {
+            Update-AppConfigFromCache -AppConfig $script:AppConfigurations[$entry.Name] -Cached $entry.Value
         }
-
-        $appConfig = $script:AppConfigurations[$entry.Name]
-        $cached = $entry.Value
-
-        if ([string]::IsNullOrWhiteSpace($cached.Version)) {
-            continue
-        }
-
-        # Keep the seed when it is demonstrably newer than the cache
-        $seedVersion = $appConfig.FallbackVersion
-        if ($seedVersion) {
-            $seedParsed = $null
-            $cachedParsed = $null
-            if ([version]::TryParse($seedVersion, [ref]$seedParsed) -and
-                [version]::TryParse($cached.Version, [ref]$cachedParsed) -and
-                $seedParsed -gt $cachedParsed) {
-                continue
-            }
-        }
-
-        $appConfig.FallbackVersion = $cached.Version
-        if ($cached.Url) { $appConfig.FallbackUrl = $cached.Url }
-        # Recorded alongside the URL because FilenameTemplate cannot always reproduce the real
-        # asset name (7-Zip's 7z2602-x64.msi, Inkscape's dated builds, Next-Exam's build stamps)
-        if ($cached.Filename) { $appConfig.FallbackFilename = $cached.Filename }
     }
 }
 

--- a/AppInventory.ps1
+++ b/AppInventory.ps1
@@ -22,6 +22,158 @@ $script:SupersedenceGraphWarnAt = 9
 # families are inflated (a reporting caveat only - it has no Company Portal effect).
 $script:InflatingOperators = @('greaterThanOrEqual', 'greaterThan', 'notEqual')
 
+# Graph timestamps arrive as strings; a missing one stays $null instead of becoming 01/01/0001.
+function ConvertTo-AppInventoryDateTime {
+    param([AllowNull()]$Value)
+
+    if (-not $Value) { return $null }
+    return [datetime]$Value
+}
+
+# The family whose base name an unmanaged app shares without following its naming convention -
+# longest base name first, so "Firefox ESR" wins over "Firefox". $null when it resembles none.
+function Get-AppFamilyNearMiss {
+    param(
+        [Parameter(Mandatory = $true)] [AllowEmptyString()] [string]$DisplayName,
+        [Parameter(Mandatory = $true)] [AllowEmptyCollection()] [array]$Families
+    )
+
+    foreach ($candidate in ($Families | Sort-Object { $_.BaseName.Length } -Descending)) {
+        if ($DisplayName.StartsWith($candidate.BaseName, [System.StringComparison]::OrdinalIgnoreCase)) {
+            return $candidate.AppConfigName
+        }
+    }
+    return $null
+}
+
+# The JSON-friendly version block of a record; $null when no version could be read at all.
+function ConvertTo-AppVersionRecord {
+    param([AllowNull()]$VersionInfo)
+
+    if (-not $VersionInfo) { return $null }
+
+    $parsed = $null
+    if ($VersionInfo.Version) { $parsed = $VersionInfo.Version.ToString() }
+    return [ordered]@{ Raw = $VersionInfo.Raw; Parsed = $parsed; Source = $VersionInfo.Source }
+}
+
+# One entry per detection rule: its Graph type without the namespace, and its operator (script
+# rules have none).
+function ConvertTo-AppDetectionRecord {
+    param([Parameter(Mandatory = $true)] $App)
+
+    # ,@() so a rule-less app yields an empty array rather than $null (return unrolls)
+    $rules = @(foreach ($rule in @($App.detectionRules)) {
+        $operator = $null
+        if ($rule.PSObject.Properties.Name -contains 'operator') { $operator = "$($rule.operator)" }
+        [ordered]@{
+            Type     = "$($rule.'@odata.type')" -replace '^#microsoft\.graph\.', ''
+            Operator = $operator
+        }
+    })
+    return ,$rules
+}
+
+# $true when the app detects itself with a rule under which an older version keeps "detecting" as
+# installed once a newer one is present (see $script:InflatingOperators).
+function Test-AppInflatingDetection {
+    param([Parameter(Mandatory = $true)] [AllowEmptyCollection()] [array]$Detection)
+
+    return [bool]($Detection | Where-Object {
+        $_.Type -eq 'win32LobAppPowerShellScriptDetection' -or ($_.Operator -and $script:InflatingOperators -contains $_.Operator)
+    })
+}
+
+# One entry per assignment, with the group display name resolved where it is known.
+function ConvertTo-AppAssignmentRecord {
+    param(
+        [AllowNull()] $Assignments,
+        [hashtable]$GroupNames = @{}
+    )
+
+    # @($null) iterates once in PowerShell - a failed read ($Assignments = $null) must yield an
+    # empty set here, with AssignmentsUnavailable carrying the "unknown" state.
+    $records = @(foreach ($assignment in @($Assignments)) {
+        if ($null -eq $assignment) { continue }
+
+        $groupName = $null
+        if ($assignment.GroupId -and $GroupNames.ContainsKey($assignment.GroupId)) {
+            $groupName = $GroupNames[$assignment.GroupId]
+        }
+
+        [ordered]@{
+            Intent               = $assignment.Intent
+            Target               = $assignment.Target
+            GroupId              = $assignment.GroupId
+            GroupName            = $groupName
+            AutoUpdateSuperseded = $assignment.AutoUpdateSuperseded
+        }
+    })
+    return ,$records
+}
+
+# Which bucket a relationship belongs in, from its Graph type and whether the app is the child of
+# the relationship. $null for a relationship type the inventory does not track.
+function Get-AppRelationshipBucket {
+    param(
+        [AllowEmptyString()] [string]$ODataType,
+        [bool]$IsChild
+    )
+
+    if ($ODataType -like '*mobileAppSupersedence') {
+        if ($IsChild) { return 'Supersedes' }
+        return 'SupersededBy'
+    }
+    if ($ODataType -like '*mobileAppDependency') {
+        if ($IsChild) { return 'DependsOn' }
+        return 'DependencyOf'
+    }
+    return $null
+}
+
+# The app's relationships split into @{ Supersedes; SupersededBy; DependsOn; DependencyOf }.
+function Split-AppRelationshipRecord {
+    param([AllowNull()] $Relationships)
+
+    $buckets = @{ Supersedes = @(); SupersededBy = @(); DependsOn = @(); DependencyOf = @() }
+
+    foreach ($relationship in @($Relationships)) {
+        $bucket = Get-AppRelationshipBucket -ODataType "$($relationship.'@odata.type')" -IsChild ("$($relationship.targetType)" -eq 'child')
+        if (-not $bucket) { continue }
+
+        $entry = [ordered]@{
+            TargetId             = $relationship.targetId
+            TargetDisplayName    = $relationship.targetDisplayName
+            TargetDisplayVersion = $relationship.targetDisplayVersion
+        }
+        if ($bucket -in 'Supersedes', 'SupersededBy') {
+            $entry['SupersedenceType'] = $relationship.supersedenceType
+        }
+        else {
+            $entry['DependencyType'] = $relationship.dependencyType
+        }
+
+        $buckets[$bucket] += $entry
+    }
+
+    return $buckets
+}
+
+# The device/user install counts Graph reported, $null when the summary could not be read.
+function ConvertTo-AppInstallSummaryRecord {
+    param([AllowNull()] $InstallSummary)
+
+    if ($null -eq $InstallSummary) { return $null }
+
+    $summary = [ordered]@{}
+    foreach ($name in 'installedDeviceCount', 'failedDeviceCount', 'notInstalledDeviceCount', 'pendingInstallDeviceCount', 'notApplicableDeviceCount', 'installedUserCount', 'failedUserCount', 'notInstalledUserCount', 'pendingInstallUserCount', 'notApplicableUserCount') {
+        if ($InstallSummary.PSObject.Properties.Name -contains $name) {
+            $summary[$name] = $InstallSummary.$name
+        }
+    }
+    return $summary
+}
+
 # One normalized, JSON-friendly record per Intune app.
 #   -App            raw win32LobApp object (largeIcon is dropped)
 #   -Assignments    Get-InteropAppAssignmentDetail output (may be $null on read failure)
@@ -44,95 +196,216 @@ function ConvertTo-AppInventoryRecord {
     # Near miss: shares a family's base name but does not follow its naming convention
     $nearMiss = $null
     if ($null -eq $family) {
-        foreach ($candidate in ($Families | Sort-Object { $_.BaseName.Length } -Descending)) {
-            if ("$($App.displayName)".StartsWith($candidate.BaseName, [System.StringComparison]::OrdinalIgnoreCase)) {
-                $nearMiss = $candidate.AppConfigName
-                break
-            }
-        }
+        $nearMiss = Get-AppFamilyNearMiss -DisplayName "$($App.displayName)" -Families $Families
     }
 
     $versionInfo = Get-IntuneAppVersion -App $App
-
-    $detection = @(foreach ($rule in @($App.detectionRules)) {
-        [ordered]@{
-            Type     = "$($rule.'@odata.type')" -replace '^#microsoft\.graph\.', ''
-            Operator = if ($rule.PSObject.Properties.Name -contains 'operator') { "$($rule.operator)" } else { $null }
-        }
-    })
-    $inflating = [bool]($detection | Where-Object {
-        $_.Type -eq 'win32LobAppPowerShellScriptDetection' -or ($_.Operator -and $script:InflatingOperators -contains $_.Operator)
-    })
-
-    # @($null) iterates once in PowerShell - a failed read ($Assignments = $null) must yield an
-    # empty set here, with AssignmentsUnavailable carrying the "unknown" state.
-    $assignmentRecords = @(foreach ($assignment in @($Assignments)) {
-        if ($null -eq $assignment) { continue }
-        [ordered]@{
-            Intent               = $assignment.Intent
-            Target               = $assignment.Target
-            GroupId              = $assignment.GroupId
-            GroupName            = if ($assignment.GroupId -and $GroupNames.ContainsKey($assignment.GroupId)) { $GroupNames[$assignment.GroupId] } else { $null }
-            AutoUpdateSuperseded = $assignment.AutoUpdateSuperseded
-        }
-    })
-
-    $supersedes = @(); $supersededBy = @(); $dependsOn = @(); $dependencyOf = @()
-    foreach ($relationship in @($Relationships)) {
-        $entry = [ordered]@{
-            TargetId             = $relationship.targetId
-            TargetDisplayName    = $relationship.targetDisplayName
-            TargetDisplayVersion = $relationship.targetDisplayVersion
-        }
-        $isChild = ("$($relationship.targetType)" -eq 'child')
-        switch -Wildcard ("$($relationship.'@odata.type')") {
-            '*mobileAppSupersedence' {
-                $entry['SupersedenceType'] = $relationship.supersedenceType
-                if ($isChild) { $supersedes += $entry } else { $supersededBy += $entry }
-            }
-            '*mobileAppDependency' {
-                $entry['DependencyType'] = $relationship.dependencyType
-                if ($isChild) { $dependsOn += $entry } else { $dependencyOf += $entry }
-            }
-        }
-    }
-
-    $summary = $null
-    if ($null -ne $InstallSummary) {
-        $summary = [ordered]@{}
-        foreach ($name in 'installedDeviceCount', 'failedDeviceCount', 'notInstalledDeviceCount', 'pendingInstallDeviceCount', 'notApplicableDeviceCount', 'installedUserCount', 'failedUserCount', 'notInstalledUserCount', 'pendingInstallUserCount', 'notApplicableUserCount') {
-            if ($InstallSummary.PSObject.Properties.Name -contains $name) {
-                $summary[$name] = $InstallSummary.$name
-            }
-        }
-    }
+    $detection = ConvertTo-AppDetectionRecord -App $App
+    $related = Split-AppRelationshipRecord -Relationships $Relationships
 
     return [PSCustomObject]@{
         Id                    = $App.id
         DisplayName           = $App.displayName
         DisplayVersion        = $App.displayVersion
         Publisher             = $App.publisher
-        CreatedDateTime       = if ($App.createdDateTime) { [datetime]$App.createdDateTime } else { $null }
-        LastModifiedDateTime  = if ($App.lastModifiedDateTime) { [datetime]$App.lastModifiedDateTime } else { $null }
+        CreatedDateTime       = ConvertTo-AppInventoryDateTime -Value $App.createdDateTime
+        LastModifiedDateTime  = ConvertTo-AppInventoryDateTime -Value $App.lastModifiedDateTime
         IsAssigned            = $App.isAssigned
         PublishingState       = $App.publishingState
         Size                  = $App.size
-        Family                = if ($family) { $family.AppConfigName } else { $null }
+        Family                = $family.AppConfigName
         FamilyNearMiss        = $nearMiss
-        Version               = if ($versionInfo) { [ordered]@{ Raw = $versionInfo.Raw; Parsed = if ($versionInfo.Version) { $versionInfo.Version.ToString() } else { $null }; Source = $versionInfo.Source } } else { $null }
-        ParsedVersion         = if ($versionInfo) { $versionInfo.Version } else { $null }
+        Version               = ConvertTo-AppVersionRecord -VersionInfo $versionInfo
+        ParsedVersion         = $versionInfo.Version
         Detection             = $detection
-        InflatingDetection    = $inflating
-        Assignments           = $assignmentRecords
+        InflatingDetection    = Test-AppInflatingDetection -Detection $detection
+        Assignments           = ConvertTo-AppAssignmentRecord -Assignments $Assignments -GroupNames $GroupNames
         AssignmentsUnavailable = ($null -eq $Assignments)
         RelationshipsUnavailable = ($null -eq $Relationships)
-        Supersedes            = $supersedes
-        SupersededBy          = $supersededBy
-        DependsOn             = $dependsOn
-        DependencyOf          = $dependencyOf
-        InstallSummary        = $summary
+        Supersedes            = $related.Supersedes
+        SupersededBy          = $related.SupersededBy
+        DependsOn             = $related.DependsOn
+        DependencyOf          = $related.DependencyOf
+        InstallSummary        = ConvertTo-AppInstallSummaryRecord -InstallSummary $InstallSummary
         Retention             = $null   # filled in by Get-AppInventoryAnalysis for managed apps
     }
+}
+
+# Writes the retention verdicts of one family onto its records.
+# An app whose relationships could not be read may be a dependency target we cannot see, and
+# dependency targets are always kept - so it must not become a delete candidate (the cleanup
+# consumes these verdicts). Downgrade to Review.
+function Set-AppInventoryRetention {
+    param(
+        [Parameter(Mandatory = $true)] [AllowEmptyCollection()] [array]$Members,
+        [Parameter(Mandatory = $true)] [AllowEmptyCollection()] [array]$Plan
+    )
+
+    foreach ($verdict in $Plan) {
+        $record = $Members | Where-Object Id -eq $verdict.Id | Select-Object -First 1
+        if ($record.RelationshipsUnavailable -and $verdict.Action -eq 'Delete') {
+            $verdict.Action = 'Review'
+            $verdict.Reasons = @($verdict.Reasons) + 'relationships could not be read - may be a dependency target; deletion suppressed, re-run the inventory'
+        }
+        $record.Retention = [ordered]@{ Rank = $verdict.Rank; AgeWeeks = $verdict.AgeWeeks; SupersededWeeks = $verdict.SupersededWeeks; Action = $verdict.Action; Reasons = @($verdict.Reasons) }
+    }
+}
+
+# Anomalies about the data the inventory could read and about the family's shape: unreadable
+# relationships, duplicate version numbers, and a supersedence graph nearing the Intune limit.
+function Get-AppFamilyDataAnomaly {
+    param(
+        [Parameter(Mandatory = $true)] [string]$FamilyName,
+        [Parameter(Mandatory = $true)] [AllowEmptyCollection()] [array]$Members,
+        [Parameter(Mandatory = $true)] [AllowEmptyCollection()] [array]$Plan,
+        $GraphNodes = 0
+    )
+
+    $anomalies = [System.Collections.Generic.List[object]]::new()
+
+    $relationshipsUnavailable = @($Members | Where-Object RelationshipsUnavailable)
+    if ($relationshipsUnavailable.Count -gt 0) {
+        $anomalies.Add((New-Anomaly -Type 'RelationshipsUnavailable' -Family $FamilyName -Message "relationships of $($relationshipsUnavailable.Count) version(s) could not be read - supersedence graph size and dependency protection are incomplete for this family and deletion of the affected version(s) is suppressed; re-run the inventory" -AppIds @($relationshipsUnavailable.Id)))
+    }
+
+    # Duplicates are detected by version number, not by the Review action - Review is also
+    # the verdict for an app whose relationships could not be read.
+    $duplicateGroups = @($Plan | Where-Object { $null -ne $_.Version } | Group-Object { $_.Version.ToString() } | Where-Object Count -gt 1)
+    foreach ($group in $duplicateGroups) {
+        $anomalies.Add((New-Anomaly -Type 'DuplicateVersion' -Family $FamilyName -Message "version $($group.Name) exists more than once - review manually, retention will not delete either copy" -AppIds @($group.Group.Id)))
+    }
+
+    if ($GraphNodes -ge $script:SupersedenceGraphWarnAt) {
+        $anomalies.Add((New-Anomaly -Type 'SupersedenceGraphNearLimit' -Family $FamilyName -Message "supersedence graph has $GraphNodes node(s); Intune allows $script:SupersedenceGraphNodeLimit - the next version's supersedence will fail once the limit is reached" -AppIds @($Members.Id)))
+    }
+
+    return @($anomalies)
+}
+
+# Anomalies about what users see in the Company Portal: an older version that shows up as a
+# separate app, and a newest version nobody can install.
+#
+# A superseded version keeping its 'available' assignment is normal and required: the Company
+# Portal hides it behind the newest version, and the assignment is what keeps supersedence/
+# auto-update working - never flag that. What does show up as a separate app in the Company
+# Portal is an older version with an 'available' assignment (the intent the portal lists) that is
+# NOT superseded by anything - a chain split at the graph limit, or a version that was never
+# linked. Required-only assignments are not visible in the portal and are left alone.
+function Get-AppFamilyPortalAnomaly {
+    param(
+        [Parameter(Mandatory = $true)] [string]$FamilyName,
+        [Parameter(Mandatory = $true)] [AllowEmptyCollection()] [array]$Members,
+        [AllowNull()] $Newest,
+        [AllowNull()] $AppConfig
+    )
+
+    $anomalies = [System.Collections.Generic.List[object]]::new()
+
+    $unlinkedOlder = @($Members | Where-Object {
+        $_.Retention.Rank -and $_.Retention.Rank -gt 1 -and
+        @($_.SupersededBy).Count -eq 0 -and -not $_.RelationshipsUnavailable -and
+        @(Select-AvailableAssignment -Assignments $_.Assignments).Count -gt 0
+    })
+    if ($unlinkedOlder.Count -gt 0) {
+        $names = ($unlinkedOlder | ForEach-Object { "$($_.DisplayName) v$($_.DisplayVersion)" }) -join ', '
+        $anomalies.Add((New-Anomaly -Type 'OlderVersionUnlinked' -Family $FamilyName -Message "$($unlinkedOlder.Count) older version(s) are assigned 'available' but not superseded by any version ($names) - they show up as separate apps in the Company Portal instead of being hidden behind the newest one. Retention deletes them once they leave the keep window; until then, make the next newer version supersede them." -AppIds @($unlinkedOlder.Id)))
+    }
+
+    $newestRecord = $null
+    if ($Newest) {
+        $newestRecord = $Members | Where-Object Id -eq $Newest.Id
+    }
+    if ($newestRecord -and @($newestRecord.Assignments).Count -eq 0 -and -not $newestRecord.AssignmentsUnavailable -and -not ($AppConfig -and $AppConfig.HideFromPortal -eq $true)) {
+        $anomalies.Add((New-Anomaly -Type 'NewestUnassigned' -Family $FamilyName -Message "the newest version ($($newestRecord.DisplayName) v$($newestRecord.DisplayVersion)) has no assignments" -AppIds @($newestRecord.Id)))
+    }
+
+    return @($anomalies)
+}
+
+# Superseding versions that are available without auto-update although the family opted into it -
+# users see them as 'New' instead of updating automatically.
+function Get-AppFamilyAutoUpdateAnomaly {
+    param(
+        [Parameter(Mandatory = $true)] [string]$FamilyName,
+        [Parameter(Mandatory = $true)] [AllowEmptyCollection()] [array]$Members,
+        [AllowNull()] $AppConfig
+    )
+
+    if (-not ($AppConfig -and $AppConfig.AutoUpdate -eq $true)) {
+        return @()
+    }
+
+    $gaps = @($Members | Where-Object {
+        @($_.Supersedes).Count -gt 0 -and
+        @(Select-AvailableAssignment -Assignments $_.Assignments | Where-Object { $_.AutoUpdateSuperseded -ne $true }).Count -gt 0
+    })
+    if ($gaps.Count -eq 0) {
+        return @()
+    }
+
+    return @(New-Anomaly -Type 'AutoUpdateNotEnabled' -Family $FamilyName -Message "$($gaps.Count) superseding version(s) have an 'available' assignment without auto-update, although AutoUpdate is enabled in AppConfig - users see them as 'New' instead of updating automatically" -AppIds @($gaps.Id))
+}
+
+# The per-family report of the analysis (see Get-AppInventoryAnalysis).
+function New-AppFamilyReport {
+    param(
+        [Parameter(Mandatory = $true)] $Family,
+        [bool]$InPlan = $true,
+        [Parameter(Mandatory = $true)] $Policy,
+        [Parameter(Mandatory = $true)] [AllowEmptyCollection()] [array]$Members,
+        [Parameter(Mandatory = $true)] [AllowEmptyCollection()] [array]$Plan,
+        [AllowNull()] $Newest,
+        $GraphNodes = 0
+    )
+
+    $newestReport = $null
+    if ($Newest) {
+        $newestReport = [ordered]@{ Id = $Newest.Id; DisplayName = $Newest.DisplayName; Version = $Newest.Version.ToString() }
+    }
+
+    return [PSCustomObject]@{
+        Family                  = $Family.AppConfigName
+        BaseName                = $Family.BaseName
+        InPlan                  = $InPlan
+        Policy                  = [ordered]@{ KeepNewest = $Policy.KeepNewest; KeepNewerThanWeeks = $Policy.KeepNewerThanWeeks; Source = $Policy.Source; OptIn = $Policy.OptIn }
+        VersionCount            = $Members.Count
+        Newest                  = $newestReport
+        OldestAgeWeeks          = ($Plan | Where-Object { $null -ne $_.AgeWeeks } | Measure-Object -Property AgeWeeks -Maximum).Maximum
+        SupersedenceGraphNodes  = $GraphNodes
+        InflatingDetection      = [bool]($Members | Where-Object InflatingDetection | Select-Object -First 1)
+        KeepCount               = @($Plan | Where-Object Action -eq 'Keep').Count
+        DeleteCandidateCount    = @($Plan | Where-Object Action -eq 'Delete').Count
+        ReviewCount             = @($Plan | Where-Object Action -eq 'Review').Count
+        DeleteCandidates        = @(Select-AppRetentionDeleteCandidates -Plan $Plan | ForEach-Object { [ordered]@{ Id = $_.Id; DisplayName = $_.DisplayName; Version = $_.Version.ToString(); AgeWeeks = $_.AgeWeeks; SupersededWeeks = $_.SupersededWeeks } })
+    }
+}
+
+# The apps no family claims, plus the NamingConventionMismatch anomaly for those that resemble
+# one. Returns @{ Unmanaged = @(...); Anomalies = @(...) }, near misses first (actionable).
+function Get-AppUnmanagedAnalysis {
+    param(
+        [Parameter(Mandatory = $true)] [AllowEmptyCollection()] [array]$Records,
+        [Parameter(Mandatory = $true)] [AllowEmptyCollection()] [array]$Families
+    )
+
+    $unmanaged = [System.Collections.Generic.List[object]]::new()
+    $anomalies = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($record in ($Records | Where-Object { $null -eq $_.Family })) {
+        # The anomaly only fires when the near-miss family is in the analysis scope (with -AppName
+        # the record may resemble an out-of-scope family); the Unmanaged listing keeps LooksLike
+        # either way.
+        $nearMissFamily = $null
+        if ($record.FamilyNearMiss) {
+            $nearMissFamily = $Families | Where-Object AppConfigName -eq $record.FamilyNearMiss | Select-Object -First 1
+        }
+        if ($nearMissFamily) {
+            $anomalies.Add((New-Anomaly -Type 'NamingConventionMismatch' -Family $record.FamilyNearMiss -Message "'$($record.DisplayName)' looks like $($record.FamilyNearMiss) but does not follow the naming convention, so it is not managed (never superseded, never deleted). Rename it to the pattern '$($nearMissFamily.Name)' with its version to bring it under management." -AppIds @($record.Id)))
+        }
+        $unmanaged.Add([ordered]@{ Id = $record.Id; DisplayName = $record.DisplayName; DisplayVersion = $record.DisplayVersion; Publisher = $record.Publisher; LooksLike = $record.FamilyNearMiss })
+    }
+
+    return @{ Unmanaged = @($unmanaged); Anomalies = @($anomalies) }
 }
 
 # Family-level analysis over the records: retention verdicts, supersedence graph sizes, anomalies.
@@ -174,102 +447,23 @@ function Get-AppInventoryAnalysis {
             [PSCustomObject]@{ Id = $_.Id; DisplayName = $_.DisplayName; Version = $_.ParsedVersion; CreatedDateTime = $_.CreatedDateTime }
         })
         $plan = @(Get-AppRetentionPlan -Apps $retentionInput -Policy @{ KeepNewest = $policy.KeepNewest; KeepNewerThanWeeks = $policy.KeepNewerThanWeeks } -ProtectedAppIds $protectedIds -Now $Now)
-        foreach ($verdict in $plan) {
-            $record = $members | Where-Object Id -eq $verdict.Id | Select-Object -First 1
-            # An app whose relationships could not be read may be a dependency target we cannot
-            # see, and dependency targets are always kept - so it must not become a delete
-            # candidate (the cleanup consumes these verdicts). Downgrade to Review.
-            if ($record.RelationshipsUnavailable -and $verdict.Action -eq 'Delete') {
-                $verdict.Action = 'Review'
-                $verdict.Reasons = @($verdict.Reasons) + 'relationships could not be read - may be a dependency target; deletion suppressed, re-run the inventory'
-            }
-            $record.Retention = [ordered]@{ Rank = $verdict.Rank; AgeWeeks = $verdict.AgeWeeks; SupersededWeeks = $verdict.SupersededWeeks; Action = $verdict.Action; Reasons = @($verdict.Reasons) }
-        }
-
-        $relationshipsUnavailable = @($members | Where-Object RelationshipsUnavailable)
-        if ($relationshipsUnavailable.Count -gt 0) {
-            $anomalies.Add((New-Anomaly -Type 'RelationshipsUnavailable' -Family $family.AppConfigName -Message "relationships of $($relationshipsUnavailable.Count) version(s) could not be read - supersedence graph size and dependency protection are incomplete for this family and deletion of the affected version(s) is suppressed; re-run the inventory" -AppIds @($relationshipsUnavailable.Id)))
-        }
+        Set-AppInventoryRetention -Members $members -Plan $plan
 
         $newest = $plan | Where-Object Rank -eq 1 | Select-Object -First 1
-        $graphNodes = ($members | ForEach-Object { $componentSize[$_.Id] } | Measure-Object -Maximum).Maximum
-        if ($null -eq $graphNodes) { $graphNodes = 0 }
+        $graphNodes = ($members | ForEach-Object { $componentSize[$_.Id] } | Measure-Object -Maximum).Maximum ?? 0
 
-        # Anomalies
-        # Duplicates are detected by version number, not by the Review action - Review is also
-        # the verdict for an app whose relationships could not be read.
-        $duplicateGroups = @($plan | Where-Object { $null -ne $_.Version } | Group-Object { $_.Version.ToString() } | Where-Object Count -gt 1)
-        foreach ($group in $duplicateGroups) {
-            $anomalies.Add((New-Anomaly -Type 'DuplicateVersion' -Family $family.AppConfigName -Message "version $($group.Name) exists more than once - review manually, retention will not delete either copy" -AppIds @($group.Group.Id)))
-        }
+        $anomalies.AddRange([object[]]@(
+            @(Get-AppFamilyDataAnomaly -FamilyName $family.AppConfigName -Members $members -Plan $plan -GraphNodes $graphNodes) +
+            @(Get-AppFamilyPortalAnomaly -FamilyName $family.AppConfigName -Members $members -Newest $newest -AppConfig $appConfig) +
+            @(Get-AppFamilyAutoUpdateAnomaly -FamilyName $family.AppConfigName -Members $members -AppConfig $appConfig)
+        ))
 
-        # A superseded version keeping its 'available' assignment is normal and required: the
-        # Company Portal hides it behind the newest version, and the assignment is what keeps
-        # supersedence/auto-update working - never flag that. What does show up as a separate
-        # app in the Company Portal is an older version with an 'available' assignment (the
-        # intent the portal lists) that is NOT superseded by anything - a chain split at the
-        # graph limit, or a version that was never linked. Required-only assignments are not
-        # visible in the portal and are left alone.
-        $unlinkedOlder = @($members | Where-Object {
-            $_.Retention.Rank -and $_.Retention.Rank -gt 1 -and
-            @($_.SupersededBy).Count -eq 0 -and -not $_.RelationshipsUnavailable -and
-            @(Select-AvailableAssignment -Assignments $_.Assignments).Count -gt 0
-        })
-        if ($unlinkedOlder.Count -gt 0) {
-            $names = ($unlinkedOlder | ForEach-Object { "$($_.DisplayName) v$($_.DisplayVersion)" }) -join ', '
-            $anomalies.Add((New-Anomaly -Type 'OlderVersionUnlinked' -Family $family.AppConfigName -Message "$($unlinkedOlder.Count) older version(s) are assigned 'available' but not superseded by any version ($names) - they show up as separate apps in the Company Portal instead of being hidden behind the newest one. Retention deletes them once they leave the keep window; until then, make the next newer version supersede them." -AppIds @($unlinkedOlder.Id)))
-        }
-
-        if ($appConfig -and $appConfig.AutoUpdate -eq $true) {
-            $gaps = @($members | Where-Object {
-                @($_.Supersedes).Count -gt 0 -and
-                @(Select-AvailableAssignment -Assignments $_.Assignments | Where-Object { $_.AutoUpdateSuperseded -ne $true }).Count -gt 0
-            })
-            if ($gaps.Count -gt 0) {
-                $anomalies.Add((New-Anomaly -Type 'AutoUpdateNotEnabled' -Family $family.AppConfigName -Message "$($gaps.Count) superseding version(s) have an 'available' assignment without auto-update, although AutoUpdate is enabled in AppConfig - users see them as 'New' instead of updating automatically" -AppIds @($gaps.Id)))
-            }
-        }
-
-        if ($newest) {
-            $newestRecord = $members | Where-Object Id -eq $newest.Id
-            if (@($newestRecord.Assignments).Count -eq 0 -and -not $newestRecord.AssignmentsUnavailable -and -not ($appConfig -and $appConfig.HideFromPortal -eq $true)) {
-                $anomalies.Add((New-Anomaly -Type 'NewestUnassigned' -Family $family.AppConfigName -Message "the newest version ($($newestRecord.DisplayName) v$($newestRecord.DisplayVersion)) has no assignments" -AppIds @($newestRecord.Id)))
-            }
-        }
-
-        if ($graphNodes -ge $script:SupersedenceGraphWarnAt) {
-            $anomalies.Add((New-Anomaly -Type 'SupersedenceGraphNearLimit' -Family $family.AppConfigName -Message "supersedence graph has $graphNodes node(s); Intune allows $script:SupersedenceGraphNodeLimit - the next version's supersedence will fail once the limit is reached" -AppIds @($members.Id)))
-        }
-
-        $familyReports.Add([PSCustomObject]@{
-            Family                  = $family.AppConfigName
-            BaseName                = $family.BaseName
-            InPlan                  = $inPlan
-            Policy                  = [ordered]@{ KeepNewest = $policy.KeepNewest; KeepNewerThanWeeks = $policy.KeepNewerThanWeeks; Source = $policy.Source; OptIn = $policy.OptIn }
-            VersionCount            = $members.Count
-            Newest                  = if ($newest) { [ordered]@{ Id = $newest.Id; DisplayName = $newest.DisplayName; Version = $newest.Version.ToString() } } else { $null }
-            OldestAgeWeeks          = ($plan | Where-Object { $null -ne $_.AgeWeeks } | Measure-Object -Property AgeWeeks -Maximum).Maximum
-            SupersedenceGraphNodes  = $graphNodes
-            InflatingDetection      = [bool]($members | Where-Object InflatingDetection | Select-Object -First 1)
-            KeepCount               = @($plan | Where-Object Action -eq 'Keep').Count
-            DeleteCandidateCount    = @($plan | Where-Object Action -eq 'Delete').Count
-            ReviewCount             = @($plan | Where-Object Action -eq 'Review').Count
-            DeleteCandidates        = @(Select-AppRetentionDeleteCandidates -Plan $plan | ForEach-Object { [ordered]@{ Id = $_.Id; DisplayName = $_.DisplayName; Version = $_.Version.ToString(); AgeWeeks = $_.AgeWeeks; SupersededWeeks = $_.SupersededWeeks } })
-        })
+        $familyReports.Add((New-AppFamilyReport -Family $family -InPlan $inPlan -Policy $policy -Members $members -Plan $plan -Newest $newest -GraphNodes $graphNodes))
     }
 
-    # Unmanaged apps: near misses first (actionable), then everything else
-    $unmanaged = [System.Collections.Generic.List[object]]::new()
-    foreach ($record in ($Records | Where-Object { $null -eq $_.Family })) {
-        # The anomaly only fires when the near-miss family is in the analysis scope (with -AppName
-        # the record may resemble an out-of-scope family); the Unmanaged listing keeps LooksLike
-        # either way.
-        $nearMissFamily = if ($record.FamilyNearMiss) { $Families | Where-Object AppConfigName -eq $record.FamilyNearMiss | Select-Object -First 1 } else { $null }
-        if ($nearMissFamily) {
-            $anomalies.Add((New-Anomaly -Type 'NamingConventionMismatch' -Family $record.FamilyNearMiss -Message "'$($record.DisplayName)' looks like $($record.FamilyNearMiss) but does not follow the naming convention, so it is not managed (never superseded, never deleted). Rename it to the pattern '$($nearMissFamily.Name)' with its version to bring it under management." -AppIds @($record.Id)))
-        }
-        $unmanaged.Add([ordered]@{ Id = $record.Id; DisplayName = $record.DisplayName; DisplayVersion = $record.DisplayVersion; Publisher = $record.Publisher; LooksLike = $record.FamilyNearMiss })
-    }
+    $unmanagedAnalysis = Get-AppUnmanagedAnalysis -Records $Records -Families $Families
+    $unmanaged = $unmanagedAnalysis.Unmanaged
+    $anomalies.AddRange([object[]]$unmanagedAnalysis.Anomalies)
 
     $managedRecords = @($Records | Where-Object { $null -ne $_.Family })
     return @{
@@ -403,6 +597,195 @@ function Get-SupersedenceComponentSizes {
     return $result
 }
 
+# The report header: the run's provenance and the summary counters.
+function Get-AppInventoryHeaderLine {
+    param(
+        [Parameter(Mandatory = $true)] [string]$TenantName,
+        [Parameter(Mandatory = $true)] [datetime]$GeneratedUtc,
+        [Parameter(Mandatory = $true)] $Summary
+    )
+
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $lines.Add("# Intune Win32 app inventory - $TenantName")
+    $lines.Add('')
+    $lines.Add("Generated $($GeneratedUtc.ToString('yyyy-MM-dd HH:mm')) UTC. Read-only snapshot; nothing was changed in Intune.")
+    $lines.Add('')
+    $lines.Add("- Win32 apps: **$($Summary.TotalWin32Apps)** ($($Summary.ManagedApps) managed by this tooling, $($Summary.UnmanagedApps) unmanaged)")
+    $lines.Add("- Families present: **$($Summary.FamiliesPresent)**, near the supersedence graph limit: **$($Summary.FamiliesNearGraphLimit)**")
+    $lines.Add("- Retention: **$($Summary.DeleteCandidates)** delete candidate(s), **$($Summary.ReviewItems)** item(s) to review")
+    if ($Summary.AppsWithUnavailableRelationships -gt 0) {
+        $lines.Add("- **Incomplete data**: relationships of **$($Summary.AppsWithUnavailableRelationships)** managed app(s) could not be read; their deletion is suppressed and graph sizes may be understated - re-run the inventory before a cleanup")
+    }
+    $lines.Add('')
+
+    return @($lines)
+}
+
+# The Families table: one row per family present in the tenant.
+function Get-AppInventoryFamilyTableLine {
+    param([Parameter(Mandatory = $true)] [hashtable]$Analysis)
+
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $lines.Add('## Families')
+    $lines.Add('')
+    $lines.Add('| Family | In plan | Versions | Newest | Oldest (weeks) | Graph nodes | Policy | Keep | Delete | Review |')
+    $lines.Add('| --- | --- | ---: | --- | ---: | ---: | --- | ---: | ---: | ---: |')
+
+    foreach ($f in ($Analysis.Families | Sort-Object Family)) {
+        $newest = if ($f.Newest) { "$($f.Newest.DisplayName) ($($f.Newest.Version))" } else { '-' }
+        $graph = if ($f.SupersedenceGraphNodes -ge $script:SupersedenceGraphWarnAt) { "**$($f.SupersedenceGraphNodes)** !" } else { "$($f.SupersedenceGraphNodes)" }
+        $inPlan = if ($f.InPlan) { 'yes' } else { 'no' }
+        $policy = "$($f.Policy.KeepNewest) / $($f.Policy.KeepNewerThanWeeks)w ($($f.Policy.Source))"
+        $lines.Add("| $($f.Family) | $inPlan | $($f.VersionCount) | $newest | $($f.OldestAgeWeeks) | $graph | $policy | $($f.KeepCount) | $($f.DeleteCandidateCount) | $($f.ReviewCount) |")
+    }
+    $lines.Add('')
+
+    return @($lines)
+}
+
+# The delete candidates, one table per family that has any.
+function Get-AppInventoryDeleteCandidateLine {
+    param([Parameter(Mandatory = $true)] [hashtable]$Analysis)
+
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $lines.Add('## Delete candidates (oldest first, per family)')
+    $lines.Add('')
+
+    $families = @($Analysis.Families | Sort-Object Family | Where-Object { $_.DeleteCandidates.Count -gt 0 })
+    foreach ($f in $families) {
+        $lines.Add("### $($f.Family)")
+        $lines.Add('')
+        $lines.Add('| App | Version | Superseded (weeks ago) | Age (weeks) |')
+        $lines.Add('| --- | --- | ---: | ---: |')
+        foreach ($c in $f.DeleteCandidates) {
+            $lines.Add("| $($c.DisplayName) | $($c.Version) | $($c.SupersededWeeks ?? '-') | $($c.AgeWeeks) |")
+        }
+        $lines.Add('')
+    }
+    if ($families.Count -eq 0) {
+        $lines.Add('None under the current policy.')
+        $lines.Add('')
+    }
+
+    return @($lines)
+}
+
+# The anomaly list, in a stable order.
+function Get-AppInventoryAnomalyLine {
+    param([Parameter(Mandatory = $true)] [hashtable]$Analysis)
+
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $lines.Add('## Anomalies')
+    $lines.Add('')
+
+    if ($Analysis.Anomalies.Count -eq 0) {
+        $lines.Add('None.')
+    }
+    foreach ($a in ($Analysis.Anomalies | Sort-Object Type, Family)) {
+        $lines.Add("- **$($a.Type)** [$($a.Family)]: $($a.Message)")
+    }
+    $lines.Add('')
+
+    return @($lines)
+}
+
+# One row of a family's version table.
+function Format-AppInventoryVersionRow {
+    param(
+        [Parameter(Mandatory = $true)] $Record,
+        [bool]$IncludesInstallSummary = $true
+    )
+
+    $assign = if ($Record.Assignments.Count -eq 0) { '-' } else { ($Record.Assignments | ForEach-Object { "$($_.Target) ($($_.Intent)$(if ($_.AutoUpdateSuperseded -eq $true) { ', auto-update' }))" }) -join '; ' }
+    $sup = if ($Record.Supersedes.Count -eq 0) { '-' } else { ($Record.Supersedes | ForEach-Object { $_.TargetDisplayVersion }) -join ', ' }
+    $created = if ($Record.CreatedDateTime) { $Record.CreatedDateTime.ToString('yyyy-MM-dd') } else { '-' }
+
+    $row = "| $($Record.Retention.Rank ?? '-') | $($Record.DisplayName) | $($Record.DisplayVersion) | $created | $($Record.Retention.AgeWeeks ?? '-') | $($Record.Retention.SupersededWeeks ?? '-') | $assign | $sup | $($Record.Retention.Action) | $($Record.Retention.Reasons -join '; ') |"
+    if ($IncludesInstallSummary) {
+        $row += if ($Record.InstallSummary) { " $($Record.InstallSummary.installedDeviceCount) / $($Record.InstallSummary.pendingInstallDeviceCount) / $($Record.InstallSummary.failedDeviceCount) |" } else { ' - |' }
+    }
+    return $row
+}
+
+# One family's version table: every version it has, newest rank first.
+function Get-AppInventoryFamilyVersionLine {
+    param(
+        [Parameter(Mandatory = $true)] $Family,
+        [Parameter(Mandatory = $true)] [AllowEmptyCollection()] [array]$Records,
+        [bool]$IncludesInstallSummary = $true
+    )
+
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $members = @($Records | Where-Object { $_.Family -eq $Family.Family } | Sort-Object { $_.Retention.Rank ?? [int]::MaxValue }, { $_.CreatedDateTime } -Descending:$false)
+
+    $inflating = if ($Family.InflatingDetection) { ' (inflating detection)' } else { '' }
+    $lines.Add("### $($Family.Family)$inflating")
+    $lines.Add('')
+
+    $header = '| Rank | App | Version | Created | Age (weeks) | Superseded (weeks ago) | Assignments | Supersedes | Action | Reasons |'
+    $sep = '| ---: | --- | --- | --- | ---: | ---: | --- | --- | --- | --- |'
+    if ($IncludesInstallSummary) {
+        $header += ' Installed / Pending / Failed |'
+        $sep += ' --- |'
+    }
+    $lines.Add($header)
+    $lines.Add($sep)
+
+    foreach ($m in $members) {
+        $lines.Add((Format-AppInventoryVersionRow -Record $m -IncludesInstallSummary $IncludesInstallSummary))
+    }
+    $lines.Add('')
+
+    return @($lines)
+}
+
+# The Versions section: one table per family.
+function Get-AppInventoryVersionLine {
+    param(
+        [Parameter(Mandatory = $true)] [hashtable]$Analysis,
+        [Parameter(Mandatory = $true)] [AllowEmptyCollection()] [array]$Records,
+        [bool]$IncludesInstallSummary = $true
+    )
+
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $lines.Add('## Versions')
+    $lines.Add('')
+    if ($IncludesInstallSummary) {
+        $lines.Add('Install counts on older versions of families marked *inflating* are unreliable: with version-comparison detection a device that has a newer version also detects every older one.')
+        $lines.Add('')
+    }
+
+    foreach ($f in ($Analysis.Families | Sort-Object Family)) {
+        $lines.AddRange([string[]]@(Get-AppInventoryFamilyVersionLine -Family $f -Records $Records -IncludesInstallSummary $IncludesInstallSummary))
+    }
+
+    return @($lines)
+}
+
+# The apps no family claims, the ones that resemble a family first.
+function Get-AppInventoryUnmanagedLine {
+    param([Parameter(Mandatory = $true)] [hashtable]$Analysis)
+
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $lines.Add('## Unmanaged apps')
+    $lines.Add('')
+
+    if ($Analysis.Unmanaged.Count -eq 0) {
+        $lines.Add('None.')
+        $lines.Add('')
+        return @($lines)
+    }
+
+    $lines.Add('| App | Version | Publisher | Looks like |')
+    $lines.Add('| --- | --- | --- | --- |')
+    foreach ($u in ($Analysis.Unmanaged | Sort-Object { $null -eq $_.LooksLike }, DisplayName)) {
+        $lines.Add("| $($u.DisplayName) | $($u.DisplayVersion) | $($u.Publisher) | $($u.LooksLike ?? '-') |")
+    }
+    $lines.Add('')
+
+    return @($lines)
+}
+
 # Human-readable Markdown report.
 function Format-AppInventoryMarkdown {
     param(
@@ -413,102 +796,14 @@ function Format-AppInventoryMarkdown {
         [bool]$IncludesInstallSummary = $true
     )
 
-    $lines = [System.Collections.Generic.List[string]]::new()
-    $s = $Analysis.Summary
-    $lines.Add("# Intune Win32 app inventory - $TenantName")
-    $lines.Add('')
-    $lines.Add("Generated $($GeneratedUtc.ToString('yyyy-MM-dd HH:mm')) UTC. Read-only snapshot; nothing was changed in Intune.")
-    $lines.Add('')
-    $lines.Add("- Win32 apps: **$($s.TotalWin32Apps)** ($($s.ManagedApps) managed by this tooling, $($s.UnmanagedApps) unmanaged)")
-    $lines.Add("- Families present: **$($s.FamiliesPresent)**, near the supersedence graph limit: **$($s.FamiliesNearGraphLimit)**")
-    $lines.Add("- Retention: **$($s.DeleteCandidates)** delete candidate(s), **$($s.ReviewItems)** item(s) to review")
-    if ($s.AppsWithUnavailableRelationships -gt 0) {
-        $lines.Add("- **Incomplete data**: relationships of **$($s.AppsWithUnavailableRelationships)** managed app(s) could not be read; their deletion is suppressed and graph sizes may be understated - re-run the inventory before a cleanup")
-    }
-    $lines.Add('')
-
-    $lines.Add('## Families')
-    $lines.Add('')
-    $lines.Add('| Family | In plan | Versions | Newest | Oldest (weeks) | Graph nodes | Policy | Keep | Delete | Review |')
-    $lines.Add('| --- | --- | ---: | --- | ---: | ---: | --- | ---: | ---: | ---: |')
-    foreach ($f in ($Analysis.Families | Sort-Object Family)) {
-        $newest = if ($f.Newest) { "$($f.Newest.DisplayName) ($($f.Newest.Version))" } else { '-' }
-        $graph = if ($f.SupersedenceGraphNodes -ge $script:SupersedenceGraphWarnAt) { "**$($f.SupersedenceGraphNodes)** !" } else { "$($f.SupersedenceGraphNodes)" }
-        $policy = "$($f.Policy.KeepNewest) / $($f.Policy.KeepNewerThanWeeks)w ($($f.Policy.Source))"
-        $lines.Add("| $($f.Family) | $(if ($f.InPlan) { 'yes' } else { 'no' }) | $($f.VersionCount) | $newest | $($f.OldestAgeWeeks) | $graph | $policy | $($f.KeepCount) | $($f.DeleteCandidateCount) | $($f.ReviewCount) |")
-    }
-    $lines.Add('')
-
-    $lines.Add('## Delete candidates (oldest first, per family)')
-    $lines.Add('')
-    $any = $false
-    foreach ($f in ($Analysis.Families | Sort-Object Family)) {
-        if ($f.DeleteCandidates.Count -eq 0) { continue }
-        $any = $true
-        $lines.Add("### $($f.Family)")
-        $lines.Add('')
-        $lines.Add('| App | Version | Superseded (weeks ago) | Age (weeks) |')
-        $lines.Add('| --- | --- | ---: | ---: |')
-        foreach ($c in $f.DeleteCandidates) {
-            $lines.Add("| $($c.DisplayName) | $($c.Version) | $($c.SupersededWeeks ?? '-') | $($c.AgeWeeks) |")
-        }
-        $lines.Add('')
-    }
-    if (-not $any) { $lines.Add('None under the current policy.'); $lines.Add('') }
-
-    $lines.Add('## Anomalies')
-    $lines.Add('')
-    if ($Analysis.Anomalies.Count -eq 0) {
-        $lines.Add('None.')
-    }
-    else {
-        foreach ($a in ($Analysis.Anomalies | Sort-Object Type, Family)) {
-            $lines.Add("- **$($a.Type)** [$($a.Family)]: $($a.Message)")
-        }
-    }
-    $lines.Add('')
-
-    $lines.Add('## Versions')
-    $lines.Add('')
-    if ($IncludesInstallSummary) {
-        $lines.Add('Install counts on older versions of families marked *inflating* are unreliable: with version-comparison detection a device that has a newer version also detects every older one.')
-        $lines.Add('')
-    }
-    foreach ($f in ($Analysis.Families | Sort-Object Family)) {
-        $members = @($Records | Where-Object { $_.Family -eq $f.Family } | Sort-Object { $_.Retention.Rank ?? [int]::MaxValue }, { $_.CreatedDateTime } -Descending:$false)
-        $lines.Add("### $($f.Family)$(if ($f.InflatingDetection) { ' (inflating detection)' })")
-        $lines.Add('')
-        $header = '| Rank | App | Version | Created | Age (weeks) | Superseded (weeks ago) | Assignments | Supersedes | Action | Reasons |'
-        $sep = '| ---: | --- | --- | --- | ---: | ---: | --- | --- | --- | --- |'
-        if ($IncludesInstallSummary) { $header += ' Installed / Pending / Failed |'; $sep += ' --- |' }
-        $lines.Add($header)
-        $lines.Add($sep)
-        foreach ($m in $members) {
-            $assign = if ($m.Assignments.Count -eq 0) { '-' } else { ($m.Assignments | ForEach-Object { "$($_.Target) ($($_.Intent)$(if ($_.AutoUpdateSuperseded -eq $true) { ', auto-update' }))" }) -join '; ' }
-            $sup = if ($m.Supersedes.Count -eq 0) { '-' } else { ($m.Supersedes | ForEach-Object { $_.TargetDisplayVersion }) -join ', ' }
-            $created = if ($m.CreatedDateTime) { $m.CreatedDateTime.ToString('yyyy-MM-dd') } else { '-' }
-            $row = "| $($m.Retention.Rank ?? '-') | $($m.DisplayName) | $($m.DisplayVersion) | $created | $($m.Retention.AgeWeeks ?? '-') | $($m.Retention.SupersededWeeks ?? '-') | $assign | $sup | $($m.Retention.Action) | $($m.Retention.Reasons -join '; ') |"
-            if ($IncludesInstallSummary) {
-                $row += if ($m.InstallSummary) { " $($m.InstallSummary.installedDeviceCount) / $($m.InstallSummary.pendingInstallDeviceCount) / $($m.InstallSummary.failedDeviceCount) |" } else { ' - |' }
-            }
-            $lines.Add($row)
-        }
-        $lines.Add('')
-    }
-
-    $lines.Add('## Unmanaged apps')
-    $lines.Add('')
-    if ($Analysis.Unmanaged.Count -eq 0) {
-        $lines.Add('None.')
-    }
-    else {
-        $lines.Add('| App | Version | Publisher | Looks like |')
-        $lines.Add('| --- | --- | --- | --- |')
-        foreach ($u in ($Analysis.Unmanaged | Sort-Object { $null -eq $_.LooksLike }, DisplayName)) {
-            $lines.Add("| $($u.DisplayName) | $($u.DisplayVersion) | $($u.Publisher) | $($u.LooksLike ?? '-') |")
-        }
-    }
-    $lines.Add('')
+    $lines = @(
+        @(Get-AppInventoryHeaderLine -TenantName $TenantName -GeneratedUtc $GeneratedUtc -Summary $Analysis.Summary) +
+        @(Get-AppInventoryFamilyTableLine -Analysis $Analysis) +
+        @(Get-AppInventoryDeleteCandidateLine -Analysis $Analysis) +
+        @(Get-AppInventoryAnomalyLine -Analysis $Analysis) +
+        @(Get-AppInventoryVersionLine -Analysis $Analysis -Records $Records -IncludesInstallSummary $IncludesInstallSummary) +
+        @(Get-AppInventoryUnmanagedLine -Analysis $Analysis)
+    )
 
     return ($lines -join "`n")
 }

--- a/AppRetention.ps1
+++ b/AppRetention.ps1
@@ -27,6 +27,194 @@
 # SupersededWeeks the weeks since then - the number the window rule is about.
 # Rank counts distinct version numbers (duplicates share a rank), so a duplicate never consumes a
 # KeepNewest slot. Unparseable versions have no rank.
+# Weeks between a creation time and $Now, $null when the creation time is unknown.
+function Get-AppRetentionAgeWeeks {
+    param($CreatedDateTime, [datetime]$Now)
+
+    if ($null -eq $CreatedDateTime) { return $null }
+    return [math]::Round(($Now - [datetime]$CreatedDateTime).TotalDays / 7, 1)
+}
+
+# Distinct-version ranks (1 = newest) and how many apps share each version string, both keyed by
+# version string. Duplicates share a rank, so a duplicate never consumes a KeepNewest slot.
+function Get-AppRetentionVersionRank {
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [array]$Ordered
+    )
+
+    $rankByVersion = @{}
+    $countByVersion = @{}
+    $rank = 0
+    foreach ($app in $Ordered) {
+        $key = $app.Version.ToString()
+        if (-not $rankByVersion.ContainsKey($key)) {
+            $rank++
+            $rankByVersion[$key] = $rank
+            $countByVersion[$key] = 0
+        }
+        $countByVersion[$key]++
+    }
+
+    return @{ Rank = $rankByVersion; Count = $countByVersion }
+}
+
+# When did this version stop being the newest? At the creation of the first newer version. A
+# device that last checked in before that moment may still run this version, so it stays as long
+# as that moment lies inside the window. Returns @{ At; Weeks; Reason }, where Reason is the Keep
+# reason that moment earns ($null once the version has aged out of the window). The newest version
+# is never superseded; a newer version without a creation date makes the moment unknowable, which
+# is itself a Keep reason.
+function Get-AppRetentionSupersession {
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [array]$Ordered,
+
+        [Parameter(Mandatory = $true)]
+        $App,
+
+        [Parameter(Mandatory = $true)]
+        [int]$Rank,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Policy,
+
+        [Parameter(Mandatory = $true)]
+        [datetime]$Now
+    )
+
+    if ($Rank -le 1) {
+        return @{ At = $null; Weeks = $null; Reason = $null }
+    }
+
+    $newerDates = @($Ordered | Where-Object { $_.Version -gt $App.Version } | ForEach-Object { $_.CreatedDateTime })
+    if (@($newerDates | Where-Object { $null -eq $_ }).Count -gt 0) {
+        return @{ At = $null; Weeks = $null; Reason = 'superseded at an unknown time (a newer version has no creation date)' }
+    }
+
+    $at = ($newerDates | ForEach-Object { [datetime]$_ } | Measure-Object -Minimum).Minimum
+    $weeks = [math]::Round(($Now - $at).TotalDays / 7, 1)
+    $windowStart = $Now.AddDays(-7 * [int]$Policy.KeepNewerThanWeeks)
+    $reason = $null
+    if ($at -ge $windowStart) {
+        $reason = "current until $weeks weeks ago (within $($Policy.KeepNewerThanWeeks) weeks)"
+    }
+
+    return @{ At = $at; Weeks = $weeks; Reason = $reason }
+}
+
+# The plan entry for one version with a parseable version number: every Keep reason it earns, and
+# Delete only when it earned none.
+function New-AppRetentionEntry {
+    param(
+        [Parameter(Mandatory = $true)]
+        $App,
+
+        [Parameter(Mandatory = $true)]
+        [int]$Rank,
+
+        # How many apps share this version number - more than one means Review
+        [Parameter(Mandatory = $true)]
+        [int]$DuplicateCount,
+
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [array]$Ordered,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Policy,
+
+        [string[]]$ProtectedAppIds = @(),
+
+        [Parameter(Mandatory = $true)]
+        [datetime]$Now
+    )
+
+    $keepNewest = [int]$Policy.KeepNewest
+    $reasons = [System.Collections.Generic.List[string]]::new()
+
+    if ($Rank -eq 1) {
+        $reasons.Add('newest version')
+    }
+    elseif ($Rank -le $keepNewest) {
+        $reasons.Add("within newest $keepNewest")
+    }
+
+    if ($null -eq $App.CreatedDateTime) {
+        $reasons.Add('unknown creation date')
+    }
+
+    $superseded = Get-AppRetentionSupersession -Ordered $Ordered -App $App -Rank $Rank -Policy $Policy -Now $Now
+    if ($superseded.Reason) {
+        $reasons.Add($superseded.Reason)
+    }
+
+    if ($ProtectedAppIds -contains $App.Id) {
+        $reasons.Add('protected (dependency target)')
+    }
+
+    $action = if ($reasons.Count -gt 0) { 'Keep' } else { 'Delete' }
+    if ($action -eq 'Delete') {
+        $reasons.Add("superseded $($superseded.Weeks) weeks ago (more than $($Policy.KeepNewerThanWeeks) weeks) and outside newest $keepNewest")
+    }
+
+    if ($DuplicateCount -gt 1) {
+        $reasons.Add('duplicate version - review manually')
+        $action = 'Review'
+    }
+
+    return [PSCustomObject]@{
+        Id              = $App.Id
+        DisplayName     = $App.DisplayName
+        Version         = $App.Version
+        CreatedDateTime = $App.CreatedDateTime
+        Rank            = $Rank
+        AgeWeeks        = Get-AppRetentionAgeWeeks -CreatedDateTime $App.CreatedDateTime -Now $Now
+        SupersededAt    = $superseded.At
+        SupersededWeeks = $superseded.Weeks
+        Action          = $action
+        Reasons         = @($reasons)
+    }
+}
+
+# The plan entry for a version whose version number cannot be parsed: always kept, never ranked.
+function New-AppRetentionUnparseableEntry {
+    param(
+        [Parameter(Mandatory = $true)]
+        $App,
+
+        [string[]]$ProtectedAppIds = @(),
+
+        [Parameter(Mandatory = $true)]
+        [datetime]$Now
+    )
+
+    $reasons = [System.Collections.Generic.List[string]]::new()
+    $reasons.Add('unparseable version - never deleted automatically')
+
+    if ($null -eq $App.CreatedDateTime) {
+        $reasons.Add('unknown creation date')
+    }
+    if ($ProtectedAppIds -contains $App.Id) {
+        $reasons.Add('protected (dependency target)')
+    }
+
+    return [PSCustomObject]@{
+        Id              = $App.Id
+        DisplayName     = $App.DisplayName
+        Version         = $null
+        CreatedDateTime = $App.CreatedDateTime
+        Rank            = $null
+        AgeWeeks        = Get-AppRetentionAgeWeeks -CreatedDateTime $App.CreatedDateTime -Now $Now
+        SupersededAt    = $null
+        SupersededWeeks = $null
+        Action          = 'Keep'
+        Reasons         = @($reasons)
+    }
+}
+
 function Get-AppRetentionPlan {
     param(
         # Objects with Id, DisplayName, Version ([version] or $null), CreatedDateTime ([datetime] or $null)
@@ -49,127 +237,25 @@ function Get-AppRetentionPlan {
         return @()
     }
 
-    $keepNewest = [int]$Policy.KeepNewest
-    $windowStart = $Now.AddDays(-7 * [int]$Policy.KeepNewerThanWeeks)
-
     $parseable = @($Apps | Where-Object { $null -ne $_.Version })
     $unparseable = @($Apps | Where-Object { $null -eq $_.Version })
 
     # Newest first; identical versions ordered newest-created first
     $ordered = @($parseable | Sort-Object -Property @{ Expression = 'Version'; Descending = $true }, @{ Expression = 'CreatedDateTime'; Descending = $true })
-
-    # Distinct-version ranks and duplicate detection
-    $rankByVersion = @{}
-    $countByVersion = @{}
-    $rank = 0
-    foreach ($app in $ordered) {
-        $key = $app.Version.ToString()
-        if (-not $rankByVersion.ContainsKey($key)) {
-            $rank++
-            $rankByVersion[$key] = $rank
-            $countByVersion[$key] = 0
-        }
-        $countByVersion[$key]++
-    }
+    $ranks = Get-AppRetentionVersionRank -Ordered $ordered
 
     $results = [System.Collections.Generic.List[object]]::new()
 
     foreach ($app in $ordered) {
         $key = $app.Version.ToString()
-        $appRank = $rankByVersion[$key]
-        $reasons = [System.Collections.Generic.List[string]]::new()
-        $ageWeeks = $null
-
-        if ($appRank -eq 1) {
-            $reasons.Add('newest version')
-        }
-        elseif ($appRank -le $keepNewest) {
-            $reasons.Add("within newest $keepNewest")
-        }
-
-        if ($null -eq $app.CreatedDateTime) {
-            $reasons.Add('unknown creation date')
-        }
-        else {
-            $ageWeeks = [math]::Round(($Now - [datetime]$app.CreatedDateTime).TotalDays / 7, 1)
-        }
-
-        # When did this version stop being the newest? At the creation of the first newer
-        # version. A device that last checked in before that moment may still run this version,
-        # so it stays as long as that moment lies inside the window.
-        $supersededAt = $null
-        $supersededWeeks = $null
-        if ($appRank -gt 1) {
-            $newerDates = @($ordered | Where-Object { $_.Version -gt $app.Version } | ForEach-Object { $_.CreatedDateTime })
-            if (@($newerDates | Where-Object { $null -eq $_ }).Count -gt 0) {
-                $reasons.Add('superseded at an unknown time (a newer version has no creation date)')
-            }
-            else {
-                $supersededAt = ($newerDates | ForEach-Object { [datetime]$_ } | Measure-Object -Minimum).Minimum
-                $supersededWeeks = [math]::Round(($Now - $supersededAt).TotalDays / 7, 1)
-                if ($supersededAt -ge $windowStart) {
-                    $reasons.Add("current until $supersededWeeks weeks ago (within $($Policy.KeepNewerThanWeeks) weeks)")
-                }
-            }
-        }
-
-        if ($ProtectedAppIds -contains $app.Id) {
-            $reasons.Add('protected (dependency target)')
-        }
-
-        $action = if ($reasons.Count -gt 0) { 'Keep' } else { 'Delete' }
-        if ($action -eq 'Delete') {
-            $reasons.Add("superseded $supersededWeeks weeks ago (more than $($Policy.KeepNewerThanWeeks) weeks) and outside newest $keepNewest")
-        }
-
-        if ($countByVersion[$key] -gt 1) {
-            $reasons.Add('duplicate version - review manually')
-            $action = 'Review'
-        }
-
-        $results.Add([PSCustomObject]@{
-            Id              = $app.Id
-            DisplayName     = $app.DisplayName
-            Version         = $app.Version
-            CreatedDateTime = $app.CreatedDateTime
-            Rank            = $appRank
-            AgeWeeks        = $ageWeeks
-            SupersededAt    = $supersededAt
-            SupersededWeeks = $supersededWeeks
-            Action          = $action
-            Reasons         = @($reasons)
-        })
+        $results.Add((New-AppRetentionEntry -App $app -Rank $ranks.Rank[$key] -DuplicateCount $ranks.Count[$key] -Ordered $ordered -Policy $Policy -ProtectedAppIds $ProtectedAppIds -Now $Now))
     }
 
     # Unparseable versions last, newest-created first (unknown dates at the very end), so the
     # output order is deterministic regardless of input order
     $orderedUnparseable = @($unparseable | Sort-Object -Property @{ Expression = { $null -eq $_.CreatedDateTime } }, @{ Expression = 'CreatedDateTime'; Descending = $true }, 'DisplayName')
     foreach ($app in $orderedUnparseable) {
-        $reasons = [System.Collections.Generic.List[string]]::new()
-        $reasons.Add('unparseable version - never deleted automatically')
-        $ageWeeks = $null
-        if ($null -eq $app.CreatedDateTime) {
-            $reasons.Add('unknown creation date')
-        }
-        else {
-            $ageWeeks = [math]::Round(($Now - [datetime]$app.CreatedDateTime).TotalDays / 7, 1)
-        }
-        if ($ProtectedAppIds -contains $app.Id) {
-            $reasons.Add('protected (dependency target)')
-        }
-
-        $results.Add([PSCustomObject]@{
-            Id              = $app.Id
-            DisplayName     = $app.DisplayName
-            Version         = $null
-            CreatedDateTime = $app.CreatedDateTime
-            Rank            = $null
-            AgeWeeks        = $ageWeeks
-            SupersededAt    = $null
-            SupersededWeeks = $null
-            Action          = 'Keep'
-            Reasons         = @($reasons)
-        })
+        $results.Add((New-AppRetentionUnparseableEntry -App $app -ProtectedAppIds $ProtectedAppIds -Now $Now))
     }
 
     return @($results)

--- a/Deploy-ToIntune.ps1
+++ b/Deploy-ToIntune.ps1
@@ -139,6 +139,148 @@ if ($PSCmdlet.ParameterSetName -eq 'TenantName' -and -not $ShowPlan) {
     $ClientSecret = $tenantCreds.ClientSecret
 }
 
+# Assigns the app to All Users, unless that target is already assigned. Returns the ids of the
+# assignments created here (used to enable auto-update on supersedence).
+function Add-AppAllUsersAssignment {
+    param(
+        [Parameter(Mandatory = $true)] [string]$AppId,
+        [AllowEmptyCollection()] [array]$ExistingTargets = @(),
+        [bool]$AutoUpdateSuperseded
+    )
+
+    if ($ExistingTargets -contains 'AllUsers') {
+        Write-Host "  All Users: already assigned" -ForegroundColor Gray
+        return @()
+    }
+
+    Write-Host "  Assigning to All Users..." -ForegroundColor Cyan
+    $assignment = Add-InteropAllUsersAssignment -AppId $AppId -Intent "available" -Notification "showAll" -AutoUpdateSuperseded $AutoUpdateSuperseded
+    if ($assignment -and $assignment.id) {
+        Write-Host "  Assigned to All Users" -ForegroundColor Green
+        return @($assignment.id)
+    }
+
+    Write-Host "  All Users assignment was NOT created (see warning above)" -ForegroundColor Yellow
+    return @()
+}
+
+# Assigns the app to All Devices (required intent), unless that target is already assigned.
+function Add-AppAllDevicesAssignment {
+    param(
+        [Parameter(Mandatory = $true)] [string]$AppId,
+        [AllowEmptyCollection()] [array]$ExistingTargets = @()
+    )
+
+    if ($ExistingTargets -contains 'AllDevices') {
+        Write-Host "  All Devices: already assigned" -ForegroundColor Gray
+        return
+    }
+
+    Write-Host "  Assigning to All Devices..." -ForegroundColor Cyan
+    $deviceAssignment = Add-InteropAllDevicesAssignment -AppId $AppId -Intent "required" -Notification "showAll"
+    if ($deviceAssignment -and $deviceAssignment.id) {
+        Write-Host "  Assigned to All Devices" -ForegroundColor Green
+        return
+    }
+
+    Write-Host "  All Devices assignment was NOT created (see warning above)" -ForegroundColor Yellow
+}
+
+# Resolves the Groups module once per app rather than once per group: Get-Module -ListAvailable
+# scans the whole module path, and Install-Module can prompt. $false means every group assignment
+# is skipped while the All Users / All Devices assignments stay applied. Honors -SkipInstallation
+# like Install-RequiredModules.
+function Initialize-AppGroupsModule {
+    param([bool]$SkipModuleInstallation)
+
+    try {
+        if (-not (Get-Module -ListAvailable -Name Microsoft.Graph.Groups)) {
+            if ($SkipModuleInstallation) {
+                throw "Microsoft.Graph.Groups is not installed and -SkipInstallation was specified"
+            }
+            Write-Host "  Installing Microsoft.Graph.Groups module..." -ForegroundColor Yellow
+            Install-Module -Name Microsoft.Graph.Groups -Scope CurrentUser -Force -AllowClobber
+        }
+        Import-Module Microsoft.Graph.Groups -ErrorAction Stop
+        return $true
+    }
+    catch {
+        Write-Host "  Warning: Microsoft.Graph.Groups is unavailable, skipping all group assignments" -ForegroundColor Yellow
+        Write-Host "  Error details: $($_.Exception.Message)" -ForegroundColor Yellow
+        return $false
+    }
+}
+
+# The Entra ID group of that display name, or $null when there is none. Single quotes are doubled
+# per the OData string-literal rules, so a name like "Teachers' Devices" resolves instead of
+# producing an invalid filter.
+function Resolve-EntraGroup {
+    param([Parameter(Mandatory = $true)] [string]$GroupName)
+
+    $odataGroupName = $GroupName -replace "'", "''"
+    $group = Get-MgGroup -Filter "displayName eq '$odataGroupName'" -ErrorAction Stop
+    if (-not $group) {
+        return $null
+    }
+
+    if ($group -is [array] -and $group.Count -gt 1) {
+        Write-Host "  Warning: Multiple groups found with name '$GroupName', using first match" -ForegroundColor Yellow
+        return $group[0]
+    }
+
+    return $group
+}
+
+# Assigns the app to one group of the assignment spec. Every failure is contained here: the
+# remaining groups and the rest of the app's deployment are unaffected.
+#
+# Note: group assignment IDs are deliberately not returned - matching existing behaviour, where
+# auto-update supersedence is only enabled for All Users assignments.
+function Add-AppGroupAssignment {
+    param(
+        [Parameter(Mandatory = $true)] [string]$AppId,
+        [Parameter(Mandatory = $true)] $GroupAssignment,
+        [AllowEmptyCollection()] [array]$ExistingTargets = @(),
+        [bool]$AutoUpdateSuperseded
+    )
+
+    $groupName = $GroupAssignment.Name
+    $groupIntent = if ($GroupAssignment.Intent) { $GroupAssignment.Intent } else { 'Available' }
+    Write-Host "  Assigning to group: $groupName..." -ForegroundColor Cyan
+
+    try {
+        # Ensure connection is still valid. Skips this group only.
+        if (-not (Test-IntuneConnection)) {
+            Write-Warning "  Connection lost, assignment to group '$groupName' will be skipped"
+            return
+        }
+
+        $group = Resolve-EntraGroup -GroupName $groupName
+        if (-not $group) {
+            Write-Host "  Warning: Group '$groupName' not found" -ForegroundColor Yellow
+            return
+        }
+
+        if ($ExistingTargets -contains "Group:$($group.Id)") {
+            Write-Host "  Group '$groupName': already assigned" -ForegroundColor Gray
+            return
+        }
+
+        $intent = $groupIntent.ToLower()
+        $groupResult = Add-InteropGroupAssignment -AppId $AppId -GroupId $group.Id -Intent $intent -Notification "showAll" -AutoUpdateSuperseded $AutoUpdateSuperseded
+        if ($groupResult -and $groupResult.id) {
+            Write-Host "  Assigned to group '$groupName' (ID: $($group.Id)) as $groupIntent" -ForegroundColor Green
+        }
+        else {
+            Write-Host "  Group '$groupName' assignment was NOT created (see warning above)" -ForegroundColor Yellow
+        }
+    }
+    catch {
+        Write-Host "  Warning: Failed to assign to group '$groupName': $_" -ForegroundColor Yellow
+        Write-Host "  Error details: $($_.Exception.Message)" -ForegroundColor Yellow
+    }
+}
+
 # Applies an assignment spec to an app already present in Intune and returns the IDs of the
 # assignments that were created (used to enable auto-update on supersedence).
 #
@@ -179,116 +321,420 @@ function Set-AppAssignment {
     $existingTargets = @(Get-InteropAppAssignment -AppId $AppId)
 
     if ($AssignAllUsers) {
-        if ($existingTargets -contains 'AllUsers') {
-            Write-Host "  All Users: already assigned" -ForegroundColor Gray
-        }
-        else {
-            Write-Host "  Assigning to All Users..." -ForegroundColor Cyan
-            $assignment = Add-InteropAllUsersAssignment -AppId $AppId -Intent "available" -Notification "showAll" -AutoUpdateSuperseded $AutoUpdateSuperseded
-            if ($assignment -and $assignment.id) {
-                $assignmentIds += $assignment.id
-                Write-Host "  Assigned to All Users" -ForegroundColor Green
-            }
-            else {
-                Write-Host "  All Users assignment was NOT created (see warning above)" -ForegroundColor Yellow
-            }
-        }
+        $assignmentIds += @(Add-AppAllUsersAssignment -AppId $AppId -ExistingTargets $existingTargets -AutoUpdateSuperseded $AutoUpdateSuperseded)
     }
 
     if ($AssignAllDevices) {
-        if ($existingTargets -contains 'AllDevices') {
-            Write-Host "  All Devices: already assigned" -ForegroundColor Gray
-        }
-        else {
-            Write-Host "  Assigning to All Devices..." -ForegroundColor Cyan
-            $deviceAssignment = Add-InteropAllDevicesAssignment -AppId $AppId -Intent "required" -Notification "showAll"
-            if ($deviceAssignment -and $deviceAssignment.id) {
-                Write-Host "  Assigned to All Devices" -ForegroundColor Green
-            }
-            else {
-                Write-Host "  All Devices assignment was NOT created (see warning above)" -ForegroundColor Yellow
-            }
-        }
+        Add-AppAllDevicesAssignment -AppId $AppId -ExistingTargets $existingTargets
     }
 
-    # Resolve the Groups module once per app rather than once per group: Get-Module
-    # -ListAvailable scans the whole module path, and Install-Module can prompt. If it is
-    # unavailable, skip every group assignment but keep the All Users / All Devices
-    # assignments applied above. Honors -SkipInstallation like Install-RequiredModules.
-    $groupsModuleReady = $true
-    if (@($AssignGroups).Count -gt 0) {
-        try {
-            if (-not (Get-Module -ListAvailable -Name Microsoft.Graph.Groups)) {
-                if ($SkipInstallation) {
-                    throw "Microsoft.Graph.Groups is not installed and -SkipInstallation was specified"
-                }
-                Write-Host "  Installing Microsoft.Graph.Groups module..." -ForegroundColor Yellow
-                Install-Module -Name Microsoft.Graph.Groups -Scope CurrentUser -Force -AllowClobber
-            }
-            Import-Module Microsoft.Graph.Groups -ErrorAction Stop
-        }
-        catch {
-            Write-Host "  Warning: Microsoft.Graph.Groups is unavailable, skipping all group assignments" -ForegroundColor Yellow
-            Write-Host "  Error details: $($_.Exception.Message)" -ForegroundColor Yellow
-            $groupsModuleReady = $false
-        }
+    if (@($AssignGroups).Count -eq 0) {
+        return $assignmentIds
+    }
+    if (-not (Initialize-AppGroupsModule -SkipModuleInstallation ([bool]$SkipInstallation))) {
+        return $assignmentIds
     }
 
     foreach ($groupAssignment in @($AssignGroups)) {
-        if (-not $groupsModuleReady) { break }
-
-        $groupName = $groupAssignment.Name
-        $groupIntent = if ($groupAssignment.Intent) { $groupAssignment.Intent } else { 'Available' }
-        Write-Host "  Assigning to group: $groupName..." -ForegroundColor Cyan
-
-        try {
-            # Ensure connection is still valid. Skips this group only - remaining groups
-            # and the rest of the app's deployment are unaffected.
-            if (-not (Test-IntuneConnection)) {
-                Write-Warning "  Connection lost, assignment to group '$groupName' will be skipped"
-                continue
-            }
-
-            # Query Entra ID group by display name. Single quotes are doubled per the OData
-            # string-literal rules, so a name like "Teachers' Devices" resolves instead of
-            # producing an invalid filter.
-            $odataGroupName = $groupName -replace "'", "''"
-            $group = Get-MgGroup -Filter "displayName eq '$odataGroupName'" -ErrorAction Stop
-
-            if ($group) {
-                if ($group -is [array] -and $group.Count -gt 1) {
-                    Write-Host "  Warning: Multiple groups found with name '$groupName', using first match" -ForegroundColor Yellow
-                    $group = $group[0]
-                }
-
-                if ($existingTargets -contains "Group:$($group.Id)") {
-                    Write-Host "  Group '$groupName': already assigned" -ForegroundColor Gray
-                    continue
-                }
-
-                # Note: group assignment IDs are deliberately not collected into $assignmentIds -
-                # matching existing behaviour, where auto-update supersedence is only enabled for
-                # All Users assignments.
-                $intent = $groupIntent.ToLower()
-                $groupResult = Add-InteropGroupAssignment -AppId $AppId -GroupId $group.Id -Intent $intent -Notification "showAll" -AutoUpdateSuperseded $AutoUpdateSuperseded
-                if ($groupResult -and $groupResult.id) {
-                    Write-Host "  Assigned to group '$groupName' (ID: $($group.Id)) as $groupIntent" -ForegroundColor Green
-                }
-                else {
-                    Write-Host "  Group '$groupName' assignment was NOT created (see warning above)" -ForegroundColor Yellow
-                }
-            }
-            else {
-                Write-Host "  Warning: Group '$groupName' not found" -ForegroundColor Yellow
-            }
-        }
-        catch {
-            Write-Host "  Warning: Failed to assign to group '$groupName': $_" -ForegroundColor Yellow
-            Write-Host "  Error details: $($_.Exception.Message)" -ForegroundColor Yellow
-        }
+        Add-AppGroupAssignment -AppId $AppId -GroupAssignment $groupAssignment -ExistingTargets $existingTargets -AutoUpdateSuperseded $AutoUpdateSuperseded
     }
 
     return $assignmentIds
+}
+
+# Reports one existing version and returns its raw version string, or $null when the version
+# cannot be determined at all (that app is then skipped).
+function Get-ExistingAppVersionRaw {
+    param([Parameter(Mandatory = $true)] $App)
+
+    # Version from displayVersion, else parsed from the display name (shared helper)
+    $versionInfo = Get-IntuneAppVersion -App $App
+    if ($null -eq $versionInfo) {
+        Write-Host "    - $($App.displayName) (version unknown - skipping)" -ForegroundColor Yellow
+        return $null
+    }
+
+    if ($versionInfo.Source -eq 'displayVersion') {
+        Write-Host "    - $($App.displayName) (v$($versionInfo.Raw))" -ForegroundColor Gray
+    }
+    else {
+        Write-Host "    - $($App.displayName) (v$($versionInfo.Raw) extracted from name)" -ForegroundColor Gray
+    }
+
+    return $versionInfo.Raw
+}
+
+# Compares every existing version of the family against the version to deploy and returns
+# @{ NewestOlderApp; SameVersionApp } - the version to supersede (only the newest older one, so
+# the chain stays linear) and the app that already carries this exact version ($null with
+# -ForceUpdate, which re-creates the package instead).
+function Get-AppDeploymentVersionState {
+    param(
+        [Parameter(Mandatory = $true)] [AllowEmptyCollection()] [array]$ExistingApps,
+        [Parameter(Mandatory = $true)] [string]$NewVersion,
+        [bool]$ForceUpdate
+    )
+
+    $state = @{ NewestOlderApp = $null; SameVersionApp = $null }
+    $olderApps = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($existingApp in $ExistingApps) {
+        $existingVersion = Get-ExistingAppVersionRaw -App $existingApp
+        if ($null -eq $existingVersion) { continue }
+
+        try {
+            # Compare versions
+            $existingVer = [version]$existingVersion
+            $newVer = [version]$NewVersion
+
+            if ($existingVer -lt $newVer) {
+                Write-Host "      -> Older version: $existingVersion < $NewVersion" -ForegroundColor Gray
+                $olderApps.Add([PSCustomObject]@{ App = $existingApp; Version = $existingVer })
+            }
+            elseif ($existingVer -eq $newVer) {
+                Write-Host "      -> Same version ($existingVersion = $NewVersion)" -ForegroundColor Yellow
+                if (-not $ForceUpdate) { $state.SameVersionApp = $existingApp }
+            }
+            else {
+                Write-Host "      -> Newer version exists ($existingVersion > $NewVersion)" -ForegroundColor Cyan
+            }
+        }
+        catch {
+            Write-Host "      Warning: Could not compare versions: $_" -ForegroundColor Yellow
+        }
+    }
+
+    # Track only the newest older version for supersedence (creates proper chain)
+    $state.NewestOlderApp = ($olderApps | Sort-Object Version -Descending | Select-Object -First 1).App
+    return $state
+}
+
+# Reports the family's existing versions and what the new version means for them
+# (see Get-AppDeploymentVersionState).
+function Resolve-AppDeploymentState {
+    param(
+        [AllowEmptyCollection()] [array]$ExistingApps = @(),
+        [string]$AppName,
+        [string]$NewVersion,
+        [bool]$ForceUpdate
+    )
+
+    if (-not $ExistingApps) {
+        Write-Host "  No existing apps found - creating new..." -ForegroundColor Cyan
+        return @{ NewestOlderApp = $null; SameVersionApp = $null }
+    }
+
+    Write-Host "  Found $($ExistingApps.Count) existing app(s) for '$AppName'" -ForegroundColor Yellow
+
+    # Analyze all existing apps to find versions (always check all, don't rely on exact match)
+    $state = Get-AppDeploymentVersionState -ExistingApps $ExistingApps -NewVersion $NewVersion -ForceUpdate $ForceUpdate
+
+    if ($state.NewestOlderApp) {
+        Write-Host "  Will supersede most recent older version: $($state.NewestOlderApp.displayName) v$($state.NewestOlderApp.displayVersion)" -ForegroundColor Yellow
+    }
+    if ($state.SameVersionApp) {
+        return $state
+    }
+
+    if ($state.NewestOlderApp) {
+        Write-Host "  Creating new version with supersedence..." -ForegroundColor Cyan
+    }
+    else {
+        Write-Host "  No older versions found - creating new app without supersedence" -ForegroundColor Gray
+    }
+
+    return $state
+}
+
+# Pre-flight: Intune caps a supersedence graph at 11 nodes. If the version to be superseded
+# already sits in a full graph, the upload would succeed but the supersedence would fail, leaving
+# an unlinked version - throw before uploading anything.
+function Assert-SupersedenceHeadroom {
+    param(
+        [AllowEmptyCollection()] [array]$Records = @(),
+        [AllowNull()] $NewestOlderApp,
+        [string]$AppName
+    )
+
+    if ($null -eq $NewestOlderApp) {
+        return
+    }
+
+    $headroom = Test-SupersedenceHeadroom -Records $Records -AppId $NewestOlderApp.Id
+    if ($headroom.Unknown) {
+        throw "Cannot verify that the new version can supersede $($NewestOlderApp.displayName): $($headroom.Reason). Nothing was uploaded - retry the deployment."
+    }
+    if (-not $headroom.CanAddVersion) {
+        throw "The supersedence graph of '$AppName' already has $($headroom.Nodes) node(s) - Intune's limit is $($headroom.Limit), so the new version could not supersede $($NewestOlderApp.displayName). Run .\Remove-OldIntuneAppVersions.ps1 for this tenant (or loosen its retention policy) and deploy again."
+    }
+    if ($headroom.WillFill) {
+        Write-Host "  Warning: this version fills the supersedence graph of '$AppName' ($($headroom.NodesAfter) of $($headroom.Limit) nodes); the next one will fail unless old versions are removed first" -ForegroundColor Yellow
+    }
+}
+
+# The upload parameters for one app, including its icon when there is one (a failed icon is
+# cosmetic and never stops the deployment).
+function New-AppUploadParams {
+    param(
+        [Parameter(Mandatory = $true)] [hashtable]$AppConfig,
+        [string]$IntuneWinPath,
+        [string]$IconPath
+    )
+
+    $appParams = @{
+        FilePath             = $IntuneWinPath
+        DisplayName          = $AppConfig.DisplayName
+        Description          = $AppConfig.Description
+        Publisher            = $AppConfig.Publisher
+        AppVersion           = $AppConfig.AppVersion
+        InstallExperience    = $AppConfig.InstallExperience
+        RestartBehavior      = $AppConfig.RestartBehavior
+        DetectionRule        = $AppConfig.DetectionRules
+        RequirementRule      = $AppConfig.RequirementRule
+        InstallCommandLine   = $AppConfig.InstallCommandLine
+        UninstallCommandLine = $AppConfig.UninstallCommandLine
+        Verbose              = $true
+    }
+
+    # Add icon if available (must be converted to base64)
+    if ($IconPath -and (Test-Path $IconPath)) {
+        Write-Host "  Adding app icon: $(Split-Path $IconPath -Leaf)" -ForegroundColor Gray
+        try {
+            $appParams.Icon = New-InteropAppIcon -FilePath $IconPath
+        }
+        catch {
+            Write-Host "  Warning: Failed to add icon: $_" -ForegroundColor Yellow
+        }
+    }
+
+    return $appParams
+}
+
+# Uploads the package to Intune. An Azure Storage failure mid-upload can still leave the app
+# created, so a failure is followed by a lookup before it is treated as one.
+function Publish-AppPackage {
+    param(
+        [Parameter(Mandatory = $true)] [hashtable]$AppParams,
+        [Parameter(Mandatory = $true)] [hashtable]$AppConfig
+    )
+
+    try {
+        $Win32App = Publish-InteropWin32App -AppParams $AppParams
+
+        # Validate that the app was created successfully with a valid ID
+        if (-not $Win32App -or -not $Win32App.id) {
+            throw "App creation returned but no valid app ID was provided"
+        }
+
+        Write-Host "  Successfully created new app: $($AppConfig.DisplayName) v$($AppConfig.AppVersion)" -ForegroundColor Green
+        Write-Host "    App ID: $($Win32App.id)" -ForegroundColor Gray
+        return $Win32App
+    }
+    catch {
+        Write-Host "  Warning: Upload encountered an error: $_" -ForegroundColor Yellow
+
+        # Check if app was created in Intune despite the error
+        Write-Host "  Checking if app was created in Intune..." -ForegroundColor Gray
+        Start-Sleep -Seconds 10
+
+        $createdApp = Get-InteropWin32App -DisplayName $AppConfig.DisplayName -ErrorAction SilentlyContinue
+        if ($createdApp -and $createdApp.id) {
+            Write-Host "  Found created app in Intune (ID: $($createdApp.id))" -ForegroundColor Green
+            return $createdApp
+        }
+
+        throw "App creation failed and app not found in Intune: $_"
+    }
+}
+
+# Links the new version over the versions it replaces.
+function Set-AppSupersedence {
+    param(
+        [Parameter(Mandatory = $true)] $Win32App,
+        [Parameter(Mandatory = $true)] [AllowEmptyCollection()] [array]$OldVersionApps,
+        [Parameter(Mandatory = $true)] [hashtable]$AppConfig
+    )
+
+    if ($OldVersionApps.Count -eq 0) {
+        return
+    }
+
+    Write-Host "  Setting up supersedence relationships..." -ForegroundColor Cyan
+
+    foreach ($oldApp in $OldVersionApps) {
+        try {
+            Write-Host "    Superseding: $($oldApp.displayName) v$($oldApp.displayVersion)" -ForegroundColor Gray
+
+            # Get supersedence type from app config (default to "Update" if not specified)
+            $supersedenceType = if ($AppConfig.SupersedenceType) { $AppConfig.SupersedenceType } else { "Update" }
+            Write-Host "      Supersedence type: $supersedenceType" -ForegroundColor Gray
+
+            Add-InteropSupersedence `
+                -AppId $Win32App.id `
+                -SupersededAppId $oldApp.id `
+                -SupersedenceType $supersedenceType
+
+            Write-Host "    [OK] Supersedence configured ($supersedenceType): $($oldApp.displayName) -> $($Win32App.displayName) v$($Win32App.displayVersion)" -ForegroundColor Green
+        }
+        catch {
+            # The app exists in Intune now but is not linked into the chain and has no
+            # assignments yet. Assigning it anyway would put an unlinked version into the
+            # Company Portal, so this deployment fails loudly instead.
+            throw "Failed to set supersedence for $($oldApp.displayName): $($_.Exception.Message) '$($AppConfig.DisplayName)' v$($AppConfig.AppVersion) (ID $($Win32App.id)) exists without supersedence and without assignments - delete it in Intune, fix the chain (cleanup / retention), then deploy again."
+        }
+    }
+}
+
+# Deploys a dependency that is not in Intune yet, from the package this repository builds for it
+# (no assignment - a dependency is installed through the app that depends on it).
+function Publish-DependencyApp {
+    param(
+        [Parameter(Mandatory = $true)] [string]$DependencyName,
+        [Parameter(Mandatory = $true)] $DependencyConfig
+    )
+
+    # Find the dependency's app entry in $appsToDeploy
+    $depAppEntry = $script:appsToDeploy | Where-Object { $_.AppConfigName -eq $DependencyName }
+    if (-not $depAppEntry) {
+        Write-Host "    [Err] Dependency '$DependencyName' not found in appsToDeploy" -ForegroundColor Red
+        return $null
+    }
+
+    $depFolder = Join-Path (Join-Path $BaseDir "packages") $depAppEntry.Folder
+    $depIntunewinFiles = Get-ChildItem -Path $depFolder -File |
+        Where-Object { $_.Name -like $depAppEntry.Pattern -and $_.Extension -eq ".intunewin" } |
+        Sort-Object LastWriteTime -Descending
+
+    if ($depIntunewinFiles.Count -eq 0) {
+        Write-Host "    [Err] No .intunewin package found for dependency '$DependencyName'" -ForegroundColor Red
+        Write-Host "    Run: .\Download-And-Package-Software.ps1 -AppName $DependencyName" -ForegroundColor Yellow
+        return $null
+    }
+
+    $depIntunewinFile = $depIntunewinFiles[0]
+    $depVersion = "1.0"
+    if ($depIntunewinFile.BaseName -match '(\d+\.[\d\.]+)') {
+        $depVersion = $matches[1].TrimEnd('.')
+    }
+
+    $depMetaData = Get-InteropPackageMetadata -FilePath $depIntunewinFile.FullName
+    $depSetupFile = $depMetaData.ApplicationInfo.SetupFile
+
+    # Build config for the dependency
+    if ($depAppEntry.PackageType -eq "MSI") {
+        $depAppConfig = Get-MsiAppConfig -AppName $DependencyName -Version $depVersion -SetupFile $depSetupFile -IntuneWinPath $depIntunewinFile.FullName
+    }
+    else {
+        $depAppConfig = Get-FileAppConfig -AppName $DependencyName -Version $depVersion -SetupFile $depSetupFile
+    }
+
+    # Build upload params (no assignment)
+    $depAppParams = @{
+        FilePath             = $depIntunewinFile.FullName
+        DisplayName          = $depAppConfig.DisplayName
+        Description          = $depAppConfig.Description
+        Publisher            = $depAppConfig.Publisher
+        AppVersion           = $depAppConfig.AppVersion
+        InstallExperience    = $depAppConfig.InstallExperience
+        RestartBehavior      = $depAppConfig.RestartBehavior
+        DetectionRule        = $depAppConfig.DetectionRules
+        RequirementRule      = $depAppConfig.RequirementRule
+        InstallCommandLine   = $depAppConfig.InstallCommandLine
+        UninstallCommandLine = $depAppConfig.UninstallCommandLine
+        Verbose              = $true
+    }
+
+    # Add icon if available
+    $depIconPath = Join-Path $depFolder $DependencyConfig.IconFile
+    if ($DependencyConfig.IconFile -and (Test-Path $depIconPath)) {
+        try {
+            $depAppParams.Icon = New-InteropAppIcon -FilePath $depIconPath
+        }
+        catch {
+            # The icon is cosmetic - deploy the dependency without one
+            Write-Warning "    Could not read the icon for '$DependencyName' ($depIconPath): $($_.Exception.Message)"
+        }
+    }
+
+    $depIntuneApp = Publish-InteropWin32App -AppParams $depAppParams
+    Write-Host "    Auto-deployed '$DependencyName' to Intune (ID: $($depIntuneApp.id))" -ForegroundColor Green
+    return $depIntuneApp
+}
+
+# The Intune app one dependency name refers to: the newest app of that family, auto-deployed
+# first when the tenant does not have it yet. $null when it cannot be resolved.
+function Resolve-AppDependencyApp {
+    param(
+        [Parameter(Mandatory = $true)] [string]$DependencyName,
+        [AllowNull()] $AllIntuneApps
+    )
+
+    Write-Host "    Resolving dependency: $DependencyName" -ForegroundColor Gray
+
+    # Get the dependency's config to find its display name pattern
+    $depConfig = Get-AppConfiguration -AppName $DependencyName
+    if (-not $depConfig) {
+        Write-Host "    [Err] Dependency '$DependencyName' not found in AppConfig" -ForegroundColor Red
+        return $null
+    }
+
+    # Search Intune for the newest app of the dependency's family (same naming-convention
+    # classifier as everywhere else)
+    $depNamePattern = Get-AppFamilyNamePattern -DisplayNameTemplate $depConfig.DisplayNameTemplate
+    $depIntuneApp = $AllIntuneApps | Where-Object { $_.displayName -match $depNamePattern } | Sort-Object -Property createdDateTime -Descending | Select-Object -First 1
+    if ($depIntuneApp) {
+        return $depIntuneApp
+    }
+
+    # Auto-deploy dependency if not found in Intune
+    Write-Host "    Dependency '$DependencyName' not found in Intune, auto-deploying..." -ForegroundColor Yellow
+    return (Publish-DependencyApp -DependencyName $DependencyName -DependencyConfig $depConfig)
+}
+
+# Resolves every dependency of the app and links them all in a single call. A dependency that
+# cannot be resolved is reported and left out; the app itself still deploys.
+function Set-AppDependency {
+    param(
+        [Parameter(Mandatory = $true)] $Win32App,
+        [Parameter(Mandatory = $true)] [hashtable]$AppConfig
+    )
+
+    if (-not ($AppConfig.Dependencies -and $AppConfig.Dependencies.Count -gt 0)) {
+        return
+    }
+
+    Write-Host "  Setting up dependency relationships..." -ForegroundColor Cyan
+    $dependencyAppIds = @()
+    $allIntuneApps = Get-InteropWin32App
+
+    foreach ($depName in $AppConfig.Dependencies) {
+        try {
+            $depIntuneApp = Resolve-AppDependencyApp -DependencyName $depName -AllIntuneApps $allIntuneApps
+            if (-not $depIntuneApp) { continue }
+
+            # Collect dependency app ID for batch linking
+            $dependencyAppIds += $depIntuneApp.id
+            Write-Host "    [OK] Resolved: $($depIntuneApp.displayName)" -ForegroundColor Green
+        }
+        catch {
+            Write-Host "    [Err] Failed to resolve dependency '$depName': $_" -ForegroundColor Red
+        }
+    }
+
+    if ($dependencyAppIds.Count -eq 0) {
+        return
+    }
+
+    # Link all dependencies in a single call
+    try {
+        Add-InteropDependency `
+            -AppId $Win32App.id `
+            -DependencyAppIds $dependencyAppIds
+        Write-Host "  Dependencies linked ($($dependencyAppIds.Count))" -ForegroundColor Green
+    }
+    catch {
+        Write-Host "  [Err] Failed to link dependencies: $_" -ForegroundColor Red
+    }
 }
 
 # Create app configuration and upload
@@ -327,320 +773,47 @@ function Publish-App {
         # .displayVersion / .id access below and in Get-IntuneAppVersion resolves them all the same
         # (PowerShell property access is case-insensitive; pinned by a SharedFunctions test).
         $allExistingApps = @($ExistingApps)
-        
-        if ($allExistingApps) {
-            Write-Host "  Found $($allExistingApps.Count) existing app(s) for '$AppName'" -ForegroundColor Yellow
-            
-            # Analyze all existing apps to find versions (always check all, don't rely on exact match)
-            $oldVersionApps = @()
-            $sameVersionExists = $false
-            $sameVersionApp = $null
-            $newestOlderApp = $null
-            $newestOlderVersion = $null
-            
-            foreach ($existingApp in $allExistingApps) {
-                # Version from displayVersion, else parsed from the display name (shared helper)
-                $versionInfo = Get-IntuneAppVersion -App $existingApp
-                if ($null -eq $versionInfo) {
-                    Write-Host "    - $($existingApp.displayName) (version unknown - skipping)" -ForegroundColor Yellow
-                    continue
-                }
+        $state = Resolve-AppDeploymentState -ExistingApps $allExistingApps -AppName $AppName -NewVersion $NewVersion -ForceUpdate ([bool]$ForceUpdate)
 
-                $existingVersion = $versionInfo.Raw
-                if ($versionInfo.Source -eq 'displayVersion') {
-                    Write-Host "    - $($existingApp.displayName) (v$existingVersion)" -ForegroundColor Gray
-                }
-                else {
-                    Write-Host "    - $($existingApp.displayName) (v$existingVersion extracted from name)" -ForegroundColor Gray
-                }
+        # Same version already in Intune (unless ForceUpdate): skip the upload, but still
+        # reconcile assignments. Adopting or changing a deployment plan for apps that are
+        # already deployed would otherwise silently do nothing, even though -ShowPlan
+        # reports the new assignments. Set-AppAssignment skips targets that are already
+        # assigned, so this only fills in what is missing.
+        if ($state.SameVersionApp) {
+            Write-Host "  Version $NewVersion already exists in Intune (use -ForceUpdate to recreate the package)" -ForegroundColor Yellow
+            Write-Host "  Reconciling assignments on the existing app..." -ForegroundColor Cyan
+            $null = Set-AppAssignment -AppId $state.SameVersionApp.id -AppConfig $AppConfig `
+                -AssignAllUsers $AssignAllUsers -AssignAllDevices $AssignAllDevices -AssignGroups $AssignGroups `
+                -AutoUpdateSuperseded ($AppConfig.AutoUpdate -eq $true)
+            return $state.SameVersionApp
+        }
 
-                try {
-                    # Compare versions
-                    $existingVer = [version]$existingVersion
-                    $newVer = [version]$NewVersion
-                    
-                    if ($existingVer -lt $newVer) {
-                        Write-Host "      -> Older version: $existingVersion < $NewVersion" -ForegroundColor Gray
-                        
-                        # Track only the newest older version for supersedence (creates proper chain)
-                        if ($null -eq $newestOlderVersion -or $existingVer -gt $newestOlderVersion) {
-                            $newestOlderApp = $existingApp
-                            $newestOlderVersion = $existingVer
-                        }
-                    }
-                    elseif ($existingVer -eq $newVer) {
-                        Write-Host "      -> Same version ($existingVersion = $NewVersion)" -ForegroundColor Yellow
-                        if (-not $ForceUpdate) {
-                            $sameVersionExists = $true
-                            $sameVersionApp = $existingApp
-                        }
-                    }
-                    else {
-                        Write-Host "      -> Newer version exists ($existingVersion > $NewVersion)" -ForegroundColor Cyan
-                    }
-                }
-                catch {
-                    Write-Host "      Warning: Could not compare versions: $_" -ForegroundColor Yellow
-                }
-            }
-            
-            # Add only the newest older version for supersedence
-            if ($null -ne $newestOlderApp) {
-                Write-Host "  Will supersede most recent older version: $($newestOlderApp.displayName) v$($newestOlderApp.displayVersion)" -ForegroundColor Yellow
-                $oldVersionApps = @($newestOlderApp)
-            }
-            
-            # Same version already in Intune (unless ForceUpdate): skip the upload, but still
-            # reconcile assignments. Adopting or changing a deployment plan for apps that are
-            # already deployed would otherwise silently do nothing, even though -ShowPlan
-            # reports the new assignments. Set-AppAssignment skips targets that are already
-            # assigned, so this only fills in what is missing.
-            if ($sameVersionExists) {
-                Write-Host "  Version $NewVersion already exists in Intune (use -ForceUpdate to recreate the package)" -ForegroundColor Yellow
-                Write-Host "  Reconciling assignments on the existing app..." -ForegroundColor Cyan
-                $null = Set-AppAssignment -AppId $sameVersionApp.id -AppConfig $AppConfig `
-                    -AssignAllUsers $AssignAllUsers -AssignAllDevices $AssignAllDevices -AssignGroups $AssignGroups `
-                    -AutoUpdateSuperseded ($AppConfig.AutoUpdate -eq $true)
-                return $sameVersionApp
-            }
-            
-            if ($oldVersionApps.Count -gt 0) {
-                Write-Host "  Creating new version with supersedence..." -ForegroundColor Cyan
-            }
-            else {
-                Write-Host "  No older versions found - creating new app without supersedence" -ForegroundColor Gray
-            }
-        }
-        else {
-            Write-Host "  No existing apps found - creating new..." -ForegroundColor Cyan
-        }
-            
-        # Pre-flight: Intune caps a supersedence graph at 11 nodes. If the version to be superseded
-        # already sits in a full graph, the upload would succeed but the supersedence would fail,
-        # leaving an unlinked version - stop before uploading anything.
-        if ($null -ne $newestOlderApp) {
-            $headroom = Test-SupersedenceHeadroom -Records $allExistingApps -AppId $newestOlderApp.Id
-            if ($headroom.Unknown) {
-                throw "Cannot verify that the new version can supersede $($newestOlderApp.displayName): $($headroom.Reason). Nothing was uploaded - retry the deployment."
-            }
-            if (-not $headroom.CanAddVersion) {
-                throw "The supersedence graph of '$AppName' already has $($headroom.Nodes) node(s) - Intune's limit is $($headroom.Limit), so the new version could not supersede $($newestOlderApp.displayName). Run .\Remove-OldIntuneAppVersions.ps1 for this tenant (or loosen its retention policy) and deploy again."
-            }
-            if ($headroom.WillFill) {
-                Write-Host "  Warning: this version fills the supersedence graph of '$AppName' ($($headroom.NodesAfter) of $($headroom.Limit) nodes); the next one will fail unless old versions are removed first" -ForegroundColor Yellow
-            }
-        }
+        Assert-SupersedenceHeadroom -Records $allExistingApps -NewestOlderApp $state.NewestOlderApp -AppName $AppName
 
         # Create new app
-        $appParams = @{
-            FilePath             = $IntuneWinPath
-            DisplayName          = $AppConfig.DisplayName
-            Description          = $AppConfig.Description
-            Publisher            = $AppConfig.Publisher
-            AppVersion           = $AppConfig.AppVersion
-            InstallExperience    = $AppConfig.InstallExperience
-            RestartBehavior      = $AppConfig.RestartBehavior
-            DetectionRule        = $AppConfig.DetectionRules
-            RequirementRule      = $AppConfig.RequirementRule
-            InstallCommandLine   = $AppConfig.InstallCommandLine
-            UninstallCommandLine = $AppConfig.UninstallCommandLine
-            Verbose              = $true
-        }
-            
-        # Add icon if available (must be converted to base64)
-        if ($IconPath -and (Test-Path $IconPath)) {
-            Write-Host "  Adding app icon: $(Split-Path $IconPath -Leaf)" -ForegroundColor Gray
-            try {
-                $iconFile = New-InteropAppIcon -FilePath $IconPath
-                $appParams.Icon = $iconFile
-            }
-            catch {
-                Write-Host "  Warning: Failed to add icon: $_" -ForegroundColor Yellow
-            }
-        }
-            
+        $appParams = New-AppUploadParams -AppConfig $AppConfig -IntuneWinPath $IntuneWinPath -IconPath $IconPath
+
         # Upload app to Intune with error handling for Azure Storage failures
-        $Win32App = $null
-        try {
-            $Win32App = Publish-InteropWin32App -AppParams $appParams
-                
-            # Validate that the app was created successfully with a valid ID
-            if (-not $Win32App -or -not $Win32App.id) {
-                throw "App creation returned but no valid app ID was provided"
-            }
-                
-            Write-Host "  Successfully created new app: $($AppConfig.DisplayName) v$($AppConfig.AppVersion)" -ForegroundColor Green
-            Write-Host "    App ID: $($Win32App.id)" -ForegroundColor Gray
-        }
-        catch {
-            Write-Host "  Warning: Upload encountered an error: $_" -ForegroundColor Yellow
-                
-            # Check if app was created in Intune despite the error
-            Write-Host "  Checking if app was created in Intune..." -ForegroundColor Gray
-            Start-Sleep -Seconds 10
-                
-            $createdApp = Get-InteropWin32App -DisplayName $AppConfig.DisplayName -ErrorAction SilentlyContinue
-            if ($createdApp -and $createdApp.id) {
-                Write-Host "  Found created app in Intune (ID: $($createdApp.id))" -ForegroundColor Green
-                $Win32App = $createdApp
-            }
-            else {
-                throw "App creation failed and app not found in Intune: $_"
-            }
-        }
-            
+        $Win32App = Publish-AppPackage -AppParams $appParams -AppConfig $AppConfig
+
         # Final validation
         if (-not $Win32App -or -not $Win32App.id) {
             throw "No valid app object available for supersedence and assignment operations"
         }
-                
+
         # Set up supersedence for older versions
-        if ($oldVersionApps.Count -gt 0) {
-            Write-Host "  Setting up supersedence relationships..." -ForegroundColor Cyan
-                
-            foreach ($oldApp in $oldVersionApps) {
-                try {
-                    Write-Host "    Superseding: $($oldApp.displayName) v$($oldApp.displayVersion)" -ForegroundColor Gray
-                        
-                    # Get supersedence type from app config (default to "Update" if not specified)
-                    $supersedenceType = if ($AppConfig.SupersedenceType) { $AppConfig.SupersedenceType } else { "Update" }
-                    Write-Host "      Supersedence type: $supersedenceType" -ForegroundColor Gray
-                        
-                    Add-InteropSupersedence `
-                        -AppId $Win32App.id `
-                        -SupersededAppId $oldApp.id `
-                        -SupersedenceType $supersedenceType
-                        
-                    Write-Host "    [OK] Supersedence configured ($supersedenceType): $($oldApp.displayName) -> $($Win32App.displayName) v$($Win32App.displayVersion)" -ForegroundColor Green
-                }
-                catch {
-                    # The app exists in Intune now but is not linked into the chain and has no
-                    # assignments yet. Assigning it anyway would put an unlinked version into the
-                    # Company Portal, so this deployment fails loudly instead.
-                    throw "Failed to set supersedence for $($oldApp.displayName): $($_.Exception.Message) '$($AppConfig.DisplayName)' v$($AppConfig.AppVersion) (ID $($Win32App.id)) exists without supersedence and without assignments - delete it in Intune, fix the chain (cleanup / retention), then deploy again."
-                }
-            }
-        }
-        
+        Set-AppSupersedence -Win32App $Win32App -OldVersionApps @($state.NewestOlderApp | Where-Object { $_ }) -AppConfig $AppConfig
+
         # Set up dependencies
-        if ($AppConfig.Dependencies -and $AppConfig.Dependencies.Count -gt 0) {
-            Write-Host "  Setting up dependency relationships..." -ForegroundColor Cyan
-            $dependencyAppIds = @()
-            $allIntuneApps = Get-InteropWin32App
-            
-            foreach ($depName in $AppConfig.Dependencies) {
-                try {
-                    Write-Host "    Resolving dependency: $depName" -ForegroundColor Gray
-                    
-                    # Get the dependency's config to find its display name pattern
-                    $depConfig = Get-AppConfiguration -AppName $depName
-                    if (-not $depConfig) {
-                        Write-Host "    [Err] Dependency '$depName' not found in AppConfig" -ForegroundColor Red
-                        continue
-                    }
-                    
-                    # Search Intune for the newest app of the dependency's family (same naming-convention
-                    # classifier as everywhere else)
-                    $depNamePattern = Get-AppFamilyNamePattern -DisplayNameTemplate $depConfig.DisplayNameTemplate
-                    $depIntuneApp = $allIntuneApps | Where-Object { $_.displayName -match $depNamePattern } | Sort-Object -Property createdDateTime -Descending | Select-Object -First 1
-                    
-                    # Auto-deploy dependency if not found in Intune
-                    if (-not $depIntuneApp) {
-                        Write-Host "    Dependency '$depName' not found in Intune, auto-deploying..." -ForegroundColor Yellow
-                        
-                        # Find the dependency's app entry in $appsToDeploy
-                        $depAppEntry = $script:appsToDeploy | Where-Object { $_.AppConfigName -eq $depName }
-                        if (-not $depAppEntry) {
-                            Write-Host "    [Err] Dependency '$depName' not found in appsToDeploy" -ForegroundColor Red
-                            continue
-                        }
-                        
-                        $depFolder = Join-Path (Join-Path $BaseDir "packages") $depAppEntry.Folder
-                        $depIntunewinFiles = Get-ChildItem -Path $depFolder -File |
-                            Where-Object { $_.Name -like $depAppEntry.Pattern -and $_.Extension -eq ".intunewin" } |
-                            Sort-Object LastWriteTime -Descending
-                        
-                        if ($depIntunewinFiles.Count -eq 0) {
-                            Write-Host "    [Err] No .intunewin package found for dependency '$depName'" -ForegroundColor Red
-                            Write-Host "    Run: .\Download-And-Package-Software.ps1 -AppName $depName" -ForegroundColor Yellow
-                            continue
-                        }
-                        
-                        $depIntunewinFile = $depIntunewinFiles[0]
-                        $depVersion = "1.0"
-                        if ($depIntunewinFile.BaseName -match '(\d+\.[\d\.]+)') {
-                            $depVersion = $matches[1].TrimEnd('.')
-                        }
-                        
-                        $depMetaData = Get-InteropPackageMetadata -FilePath $depIntunewinFile.FullName
-                        $depSetupFile = $depMetaData.ApplicationInfo.SetupFile
-                        
-                        # Build config for the dependency
-                        if ($depAppEntry.PackageType -eq "MSI") {
-                            $depAppConfig = Get-MsiAppConfig -AppName $depName -Version $depVersion -SetupFile $depSetupFile -IntuneWinPath $depIntunewinFile.FullName
-                        }
-                        else {
-                            $depAppConfig = Get-FileAppConfig -AppName $depName -Version $depVersion -SetupFile $depSetupFile
-                        }
-                        
-                        # Build upload params (no assignment)
-                        $depAppParams = @{
-                            FilePath             = $depIntunewinFile.FullName
-                            DisplayName          = $depAppConfig.DisplayName
-                            Description          = $depAppConfig.Description
-                            Publisher            = $depAppConfig.Publisher
-                            AppVersion           = $depAppConfig.AppVersion
-                            InstallExperience    = $depAppConfig.InstallExperience
-                            RestartBehavior      = $depAppConfig.RestartBehavior
-                            DetectionRule        = $depAppConfig.DetectionRules
-                            RequirementRule      = $depAppConfig.RequirementRule
-                            InstallCommandLine   = $depAppConfig.InstallCommandLine
-                            UninstallCommandLine = $depAppConfig.UninstallCommandLine
-                            Verbose              = $true
-                        }
-                        
-                        # Add icon if available
-                        $depIconPath = Join-Path $depFolder $depConfig.IconFile
-                        if ($depConfig.IconFile -and (Test-Path $depIconPath)) {
-                            try {
-                                $depAppParams.Icon = New-InteropAppIcon -FilePath $depIconPath
-                            }
-                            catch { }
-                        }
-                        
-                        $depIntuneApp = Publish-InteropWin32App -AppParams $depAppParams
-                        Write-Host "    Auto-deployed '$depName' to Intune (ID: $($depIntuneApp.id))" -ForegroundColor Green
-                    }
-                    
-                    # Collect dependency app ID for batch linking
-                    $dependencyAppIds += $depIntuneApp.id
-                    Write-Host "    [OK] Resolved: $($depIntuneApp.displayName)" -ForegroundColor Green
-                }
-                catch {
-                    Write-Host "    [Err] Failed to resolve dependency '$depName': $_" -ForegroundColor Red
-                }
-            }
-            
-            # Link all dependencies in a single call
-            if ($dependencyAppIds.Count -gt 0) {
-                try {
-                    Add-InteropDependency `
-                        -AppId $Win32App.id `
-                        -DependencyAppIds $dependencyAppIds
-                    Write-Host "  Dependencies linked ($($dependencyAppIds.Count))" -ForegroundColor Green
-                }
-                catch {
-                    Write-Host "  [Err] Failed to link dependencies: $_" -ForegroundColor Red
-                }
-            }
-        }
-        
+        Set-AppDependency -Win32App $Win32App -AppConfig $AppConfig
+
         # Assign if requested. Auto-update for superseded apps is requested as part of creating
         # the assignment (see Set-AppAssignment) rather than patched in afterwards.
         $null = Set-AppAssignment -AppId $Win32App.id -AppConfig $AppConfig `
             -AssignAllUsers $AssignAllUsers -AssignAllDevices $AssignAllDevices -AssignGroups $AssignGroups `
             -AutoUpdateSuperseded ($AppConfig.AutoUpdate -eq $true)
-        
+
         return $Win32App
     }
     catch {

--- a/Download-And-Package-Software.ps1
+++ b/Download-And-Package-Software.ps1
@@ -37,106 +37,186 @@ function Get-FallbackVersionInfo {
     return @{Url = $AppConfig.FallbackUrl; Version = $AppConfig.FallbackVersion; Filename = $filename}
 }
 
+# Winget manifest (7-Zip, VLC, Inkscape - unsigned installers). Version, URL and SHA-256 come as
+# one reviewed bundle; the hash replaces the Authenticode check. $null skips the app for this run:
+# deliberately no FallbackUrl here, because without a manifest hash there is nothing to verify an
+# unsigned installer against. If this persists across runs, suspect winget manifest format drift -
+# run the LocalOnly live test in tests/SharedFunctions.Tests.ps1 to diagnose.
+function Get-WingetVersionInfo {
+    param(
+        [Parameter(Mandatory=$true)]
+        [hashtable]$AppConfig
+    )
+
+    Write-Host "Resolving version from winget manifest..." -ForegroundColor Gray
+    $wingetInfo = Get-WingetInstallerInfo -PackageId $AppConfig.WingetPackageId `
+        -Architecture ($AppConfig.WingetArchitecture ?? "x64") `
+        -InstallerType $AppConfig.WingetInstallerType `
+        -AllowedUrlPrefixes $AppConfig.AllowedDownloadUrlPrefixes
+
+    if ($wingetInfo) {
+        return @{Url = $wingetInfo.Url; Version = $wingetInfo.Version; Filename = $wingetInfo.Filename; Sha256 = $wingetInfo.Sha256}
+    }
+
+    Write-Host "No verifiable winget manifest - skipping this run" -ForegroundColor Yellow
+    return $null
+}
+
+# API-based version detection (Firefox)
+function Get-ApiVersionInfo {
+    param(
+        [Parameter(Mandatory=$true)]
+        [hashtable]$AppConfig
+    )
+
+    Write-Host "Fetching version from API..." -ForegroundColor Gray
+    $versionInfo = Invoke-RestMethod -Uri $AppConfig.VersionApiUrl
+    $version = $versionInfo.($AppConfig.VersionApiProperty)
+    $filename = $AppConfig.FilenameTemplate -f $version
+
+    return @{Url = $AppConfig.DownloadUrl; Version = $version; Filename = $filename}
+}
+
+# GitHub releases (Notepad++, Audacity, OpenShot, KeePassXC, Stellarium, Next-Exam).
+# $null when the release carries no asset matching the pattern (the caller falls back).
+function Get-GitHubVersionInfo {
+    param(
+        [Parameter(Mandatory=$true)]
+        [hashtable]$AppConfig
+    )
+
+    Write-Host "Fetching version from GitHub..." -ForegroundColor Gray
+    $release = Invoke-RestMethod -Uri $AppConfig.GitHubApiUrl
+    $asset = $release.assets | Where-Object { $_.name -match $AppConfig.GitHubAssetPattern } | Select-Object -First 1
+    if (-not $asset) {
+        return $null
+    }
+
+    # Strip any leading non-digits, so "v8.9.7" and "Audacity-3.7.8" both yield a bare version
+    $version = $release.tag_name -replace '^\D*', ''
+    return @{Url = $asset.browser_download_url; Version = $version; Filename = $asset.name}
+}
+
+# LibreOffice special handling - the download page lists both the "still" (enterprise) and the
+# "fresh" line; pick the lower of the unique versions. $null when the page shows only one line
+# or nothing at all (the caller falls back).
+function Get-LibreOfficeVersionInfo {
+    param(
+        [Parameter(Mandatory=$true)]
+        [hashtable]$AppConfig,
+        [Parameter(Mandatory=$true)]
+        [AllowEmptyString()]
+        [string]$PageContent
+    )
+
+    $allMatches = [regex]::Matches($PageContent, $AppConfig.DownloadUrlRegex)
+    Write-Host "  Found $($allMatches.Count) match(es) on page" -ForegroundColor Gray
+
+    # Get unique versions
+    $uniqueVersions = @($allMatches | ForEach-Object { $_.Groups[1].Value } | Select-Object -Unique | Sort-Object)
+
+    if ($uniqueVersions.Count -ge 2) {
+        # Use the lower version (enterprise/business version)
+        $version = $uniqueVersions[0]  # First (lowest) version
+        $url = $AppConfig.DownloadUrlTemplate -f $version
+        $filename = $AppConfig.FilenameTemplate -f $version
+        Write-Host "  Found enterprise version: $version (lower of: $($uniqueVersions -join ', '))" -ForegroundColor Green
+        return @{Url = $url; Version = $version; Filename = $filename}
+    }
+
+    if ($uniqueVersions.Count -eq 1) {
+        Write-Host "  Only found 1 unique version: $($uniqueVersions[0])" -ForegroundColor Yellow
+    }
+    else {
+        Write-Host "  No matches found with regex pattern" -ForegroundColor Yellow
+    }
+    return $null
+}
+
+# Web scraping (GIMP, LibreOffice, Google Earth Pro). $null when the page does not match or the
+# app has no scraping rules here (the caller falls back).
+function Get-DownloadPageVersionInfo {
+    param(
+        [Parameter(Mandatory=$true)]
+        [hashtable]$AppConfig
+    )
+
+    Write-Host "Fetching version from download page..." -ForegroundColor Gray
+    $page = Invoke-WebRequest -Uri $AppConfig.DownloadPageUrl
+
+    if ($page.Content -notmatch $AppConfig.DownloadUrlRegex) {
+        return $null
+    }
+
+    if ($AppConfig.Name -eq "GIMP") {
+        # GIMP special handling
+        $version = $matches[1]
+        $majorMinor = $version.Substring(0, $version.LastIndexOf('.'))
+        $url = $AppConfig.DownloadUrlTemplate -f $majorMinor, $version
+        $filename = $AppConfig.FilenameTemplate -f $version
+        return @{Url = $url; Version = $version; Filename = $filename}
+    }
+
+    if ($AppConfig.Name -eq "LibreOffice") {
+        return (Get-LibreOfficeVersionInfo -AppConfig $AppConfig -PageContent $page.Content)
+    }
+
+    if ($AppConfig.Name -eq "Google Earth Pro") {
+        # Google Earth Pro - scrape version from release notes, build versioned URL
+        $version = $matches[1]  # e.g., "7.3.7"
+        $url = $AppConfig.DownloadUrlTemplate -f $version
+        $filename = $AppConfig.FilenameTemplate -f $version
+        Write-Host "  Found version: $version" -ForegroundColor Green
+        return @{Url = $url; Version = $version; Filename = $filename}
+    }
+
+    return $null
+}
+
+# Version extracted after download (Chrome, Affinity, VCRedist)
+function Get-AppLockerDownloadInfo {
+    param(
+        [Parameter(Mandatory=$true)]
+        [hashtable]$AppConfig
+    )
+
+    $uri = [System.Uri]$AppConfig.DownloadUrl
+    $filename = [System.IO.Path]::GetFileName($uri.LocalPath)
+
+    return @{Url = $AppConfig.DownloadUrl; Version = "Latest"; Filename = $filename}
+}
+
 # Generic function to get latest version info for an app
 function Get-LatestVersionInfo {
     param(
         [Parameter(Mandatory=$true)]
         [hashtable]$AppConfig
     )
-    
+
     try {
         # Handle different version detection methods
         if ($AppConfig.WingetPackageId) {
-            # Winget manifest (7-Zip, VLC, Inkscape - unsigned installers). Version, URL and
-            # SHA-256 come as one reviewed bundle; the hash replaces the Authenticode check.
-            Write-Host "Resolving version from winget manifest..." -ForegroundColor Gray
-            $wingetInfo = Get-WingetInstallerInfo -PackageId $AppConfig.WingetPackageId `
-                -Architecture ($AppConfig.WingetArchitecture ?? "x64") `
-                -InstallerType $AppConfig.WingetInstallerType `
-                -AllowedUrlPrefixes $AppConfig.AllowedDownloadUrlPrefixes
-            if ($wingetInfo) {
-                return @{Url = $wingetInfo.Url; Version = $wingetInfo.Version; Filename = $wingetInfo.Filename; Sha256 = $wingetInfo.Sha256}
-            }
-            # Deliberately no FallbackUrl here: without a manifest hash there is nothing to
-            # verify an unsigned installer against. Skip and pick it up on a later run.
-            # If this persists across runs, suspect winget manifest format drift - run the
-            # LocalOnly live test in tests/SharedFunctions.Tests.ps1 to diagnose.
-            Write-Host "No verifiable winget manifest - skipping this run" -ForegroundColor Yellow
-            return $null
+            return (Get-WingetVersionInfo -AppConfig $AppConfig)
         }
-        elseif ($AppConfig.VersionApiUrl) {
-            # API-based version detection (Firefox)
-            Write-Host "Fetching version from API..." -ForegroundColor Gray
-            $versionInfo = Invoke-RestMethod -Uri $AppConfig.VersionApiUrl
-            $version = $versionInfo.($AppConfig.VersionApiProperty)
-            $filename = $AppConfig.FilenameTemplate -f $version
-            return @{Url = $AppConfig.DownloadUrl; Version = $version; Filename = $filename}
+        if ($AppConfig.VersionApiUrl) {
+            return (Get-ApiVersionInfo -AppConfig $AppConfig)
         }
-        elseif ($AppConfig.GitHubApiUrl) {
-            # GitHub releases (Notepad++, Audacity, OpenShot, KeePassXC, Stellarium, Next-Exam)
-            Write-Host "Fetching version from GitHub..." -ForegroundColor Gray
-            $release = Invoke-RestMethod -Uri $AppConfig.GitHubApiUrl
-            $asset = $release.assets | Where-Object { $_.name -match $AppConfig.GitHubAssetPattern } | Select-Object -First 1
-            if ($asset) {
-                # Strip any leading non-digits, so "v8.9.7" and "Audacity-3.7.8" both yield a bare version
-                $version = $release.tag_name -replace '^\D*', ''
-                return @{Url = $asset.browser_download_url; Version = $version; Filename = $asset.name}
-            }
+
+        # These may come up empty-handed, and then fall back like an app with no method at all
+        $info = $null
+        if ($AppConfig.GitHubApiUrl) {
+            $info = Get-GitHubVersionInfo -AppConfig $AppConfig
         }
         elseif ($AppConfig.DownloadPageUrl -and $AppConfig.DownloadUrlRegex) {
-            # Web scraping (GIMP, LibreOffice, Google Earth Pro)
-            Write-Host "Fetching version from download page..." -ForegroundColor Gray
-            $page = Invoke-WebRequest -Uri $AppConfig.DownloadPageUrl
-
-            if ($page.Content -match $AppConfig.DownloadUrlRegex) {
-                if ($AppConfig.Name -eq "GIMP") {
-                    # GIMP special handling
-                    $version = $matches[1]
-                    $majorMinor = $version.Substring(0, $version.LastIndexOf('.'))
-                    $url = $AppConfig.DownloadUrlTemplate -f $majorMinor, $version
-                    $filename = $AppConfig.FilenameTemplate -f $version
-                    return @{Url = $url; Version = $version; Filename = $filename}
-                }
-                elseif ($AppConfig.Name -eq "LibreOffice") {
-                    # LibreOffice special handling - find unique versions and pick the lower one (enterprise/stable)
-                    $allMatches = [regex]::Matches($page.Content, $AppConfig.DownloadUrlRegex)
-                    Write-Host "  Found $($allMatches.Count) match(es) on page" -ForegroundColor Gray
-                    
-                    # Get unique versions
-                    $uniqueVersions = $allMatches | ForEach-Object { $_.Groups[1].Value } | Select-Object -Unique | Sort-Object
-                    
-                    if ($uniqueVersions.Count -ge 2) {
-                        # Use the lower version (enterprise/business version)
-                        $version = $uniqueVersions[0]  # First (lowest) version
-                        $url = $AppConfig.DownloadUrlTemplate -f $version
-                        $filename = $AppConfig.FilenameTemplate -f $version
-                        Write-Host "  Found enterprise version: $version (lower of: $($uniqueVersions -join ', '))" -ForegroundColor Green
-                        return @{Url = $url; Version = $version; Filename = $filename}
-                    }
-                    elseif ($uniqueVersions.Count -eq 1) {
-                        Write-Host "  Only found 1 unique version: $($uniqueVersions[0])" -ForegroundColor Yellow
-                    }
-                    else {
-                        Write-Host "  No matches found with regex pattern" -ForegroundColor Yellow
-                    }
-                }
-                elseif ($AppConfig.Name -eq "Google Earth Pro") {
-                    # Google Earth Pro - scrape version from release notes, build versioned URL
-                    $version = $matches[1]  # e.g., "7.3.7"
-                    $url = $AppConfig.DownloadUrlTemplate -f $version
-                    $filename = $AppConfig.FilenameTemplate -f $version
-                    Write-Host "  Found version: $version" -ForegroundColor Green
-                    return @{Url = $url; Version = $version; Filename = $filename}
-                }
-            }
+            $info = Get-DownloadPageVersionInfo -AppConfig $AppConfig
         }
         elseif ($AppConfig.VersionExtraction -eq "AppLocker") {
-            # Version extracted after download (Chrome, Affinity, VCRedist)
-            $uri = [System.Uri]$AppConfig.DownloadUrl
-            $filename = [System.IO.Path]::GetFileName($uri.LocalPath)
-            return @{Url = $AppConfig.DownloadUrl; Version = "Latest"; Filename = $filename}
+            return (Get-AppLockerDownloadInfo -AppConfig $AppConfig)
         }
-        
+        if ($info) {
+            return $info
+        }
+
         # If no method worked, use fallback
         Write-Host "Using fallback URL" -ForegroundColor Yellow
         return (Get-FallbackVersionInfo -AppConfig $AppConfig)

--- a/Get-IntuneAppInventory.ps1
+++ b/Get-IntuneAppInventory.ps1
@@ -189,19 +189,23 @@ try {
     Write-Host ("  Families present: {0}, near supersedence graph limit: {1}" -f $s.FamiliesPresent, $s.FamiliesNearGraphLimit)
     Write-Host ("  Retention: {0} delete candidate(s), {1} to review" -f $s.DeleteCandidates, $s.ReviewItems)
     Write-Host ""
-    $analysis.Families | Sort-Object Family | ForEach-Object {
-        [PSCustomObject]@{
-            Family   = $_.Family
-            InPlan   = $_.InPlan
-            Versions = $_.VersionCount
-            Newest   = if ($_.Newest) { $_.Newest.Version } else { '-' }
-            Graph    = $_.SupersedenceGraphNodes
-            Policy   = "$($_.Policy.KeepNewest)/$($_.Policy.KeepNewerThanWeeks)w"
-            Keep     = $_.KeepCount
-            Delete   = $_.DeleteCandidateCount
-            Review   = $_.ReviewCount
-        }
-    } | Format-Table -AutoSize | Out-Host
+    $analysis.Families |
+        Sort-Object Family |
+        ForEach-Object {
+            [PSCustomObject]@{
+                Family   = $_.Family
+                InPlan   = $_.InPlan
+                Versions = $_.VersionCount
+                Newest   = if ($_.Newest) { $_.Newest.Version } else { '-' }
+                Graph    = $_.SupersedenceGraphNodes
+                Policy   = "$($_.Policy.KeepNewest)/$($_.Policy.KeepNewerThanWeeks)w"
+                Keep     = $_.KeepCount
+                Delete   = $_.DeleteCandidateCount
+                Review   = $_.ReviewCount
+            }
+        } |
+        Format-Table -AutoSize |
+        Out-Host
 
     if ($analysis.Anomalies.Count -gt 0) {
         Write-Host "Anomalies:" -ForegroundColor Yellow

--- a/IntuneCleanup.ps1
+++ b/IntuneCleanup.ps1
@@ -9,6 +9,69 @@
 
 . (Join-Path $PSScriptRoot "AppCleanup.ps1")
 
+# The one-line description of a planned deletion, used for the decision prompt and the console.
+function Format-AppCleanupLabel {
+    param([Parameter(Mandatory = $true)] $Deletion)
+
+    $assignmentInfo = if ($null -ne $Deletion.AssignmentCount) { "$($Deletion.AssignmentCount) assignment(s)" } else { 'assignments unknown' }
+    $superseded = if ($null -ne $Deletion.SupersededWeeks) { "superseded $($Deletion.SupersededWeeks) weeks ago" } else { 'superseded at an unknown time' }
+
+    return "$($Deletion.DisplayName) v$($Deletion.DisplayVersion) [$($Deletion.Family)] - rank $($Deletion.Rank), $superseded, $($Deletion.AgeWeeks) weeks old, $assignmentInfo"
+}
+
+# Unlinks and deletes one version, returning @{ Outcome; Detail }.
+#
+# Everything here happens AFTER the decision (an interactive prompt may have sat open for a
+# while): the relationships are read fresh now. Intune refuses to delete an app that is part of
+# a supersedence relationship, so the version is unlinked first - unless it has become a
+# dependency target in the meantime, in which case nothing is touched.
+function Remove-IntuneAppVersion {
+    param(
+        [Parameter(Mandatory = $true)] $Deletion
+    )
+
+    try {
+        $removal = Remove-InteropAppRelationships -AppId $Deletion.Id
+    }
+    catch {
+        return @{ Outcome = 'Skipped'; Detail = "could not re-read relationships: $($_.Exception.Message)" }
+    }
+
+    if ($removal.DependencyTargets.Count -gt 0) {
+        return @{ Outcome = 'Skipped'; Detail = "is now a dependency target of: $($removal.DependencyTargets -join ', ') - nothing was changed" }
+    }
+    if ($removal.Error) {
+        return @{ Outcome = 'Failed'; Detail = "$($removal.Error) ($($removal.Removed) of $($removal.Total) relationship(s) were removed before that - the app is partially unlinked and still in Intune; re-run the cleanup)" }
+    }
+
+    try {
+        Remove-InteropWin32App -AppId $Deletion.Id
+        return @{ Outcome = 'Deleted'; Detail = "$($removal.Removed) relationship(s) removed first" }
+    }
+    catch {
+        $detail = $_.Exception.Message
+        if ($removal.Removed -gt 0) {
+            $detail += " (its $($removal.Removed) relationship(s) were already removed, so the app is now unlinked and still in Intune - re-run the cleanup)"
+        }
+        return @{ Outcome = 'Failed'; Detail = $detail }
+    }
+}
+
+# Reports one version's outcome on the console.
+function Write-AppCleanupOutcome {
+    param(
+        [Parameter(Mandatory = $true)] [string]$Outcome,
+        [Parameter(Mandatory = $true)] [string]$Label,
+        [AllowNull()] [string]$Detail
+    )
+
+    switch ($Outcome) {
+        'Deleted' { Write-Host "  Deleted $Label" -ForegroundColor Green }
+        'Skipped' { Write-Host "  Skipped $Label - $Detail" -ForegroundColor Yellow }
+        'Failed' { Write-Host "  FAILED  $Label - $Detail" -ForegroundColor Red }
+    }
+}
+
 function Invoke-IntuneAppCleanup {
     <#
     .SYNOPSIS
@@ -43,9 +106,7 @@ function Invoke-IntuneAppCleanup {
 
     $results = [System.Collections.Generic.List[object]]::new()
     foreach ($deletion in @($Plan.Deletions)) {
-        $assignmentInfo = if ($null -ne $deletion.AssignmentCount) { "$($deletion.AssignmentCount) assignment(s)" } else { 'assignments unknown' }
-        $superseded = if ($null -ne $deletion.SupersededWeeks) { "superseded $($deletion.SupersededWeeks) weeks ago" } else { 'superseded at an unknown time' }
-        $label = "$($deletion.DisplayName) v$($deletion.DisplayVersion) [$($deletion.Family)] - rank $($deletion.Rank), $superseded, $($deletion.AgeWeeks) weeks old, $assignmentInfo"
+        $label = Format-AppCleanupLabel -Deletion $deletion
         $outcome = [ordered]@{
             Id              = $deletion.Id
             Family          = $deletion.Family
@@ -68,50 +129,11 @@ function Invoke-IntuneAppCleanup {
             continue
         }
 
-        # Everything below happens AFTER the decision (an interactive prompt may have sat open
-        # for a while): the relationships are read fresh now. Intune refuses to delete an app
-        # that is part of a supersedence relationship, so the version is unlinked first - unless
-        # it has become a dependency target in the meantime, in which case nothing is touched.
-        $removal = $null
-        try {
-            $removal = Remove-InteropAppRelationships -AppId $deletion.Id
-        }
-        catch {
-            $outcome.Outcome = 'Skipped'
-            $outcome.Detail = "could not re-read relationships: $($_.Exception.Message)"
-            Write-Host "  Skipped $label - $($outcome.Detail)" -ForegroundColor Yellow
-            $results.Add([PSCustomObject]$outcome)
-            continue
-        }
-        if ($removal.DependencyTargets.Count -gt 0) {
-            $outcome.Outcome = 'Skipped'
-            $outcome.Detail = "is now a dependency target of: $($removal.DependencyTargets -join ', ') - nothing was changed"
-            Write-Host "  Skipped $label - $($outcome.Detail)" -ForegroundColor Yellow
-            $results.Add([PSCustomObject]$outcome)
-            continue
-        }
-        if ($removal.Error) {
-            $outcome.Outcome = 'Failed'
-            $outcome.Detail = "$($removal.Error) ($($removal.Removed) of $($removal.Total) relationship(s) were removed before that - the app is partially unlinked and still in Intune; re-run the cleanup)"
-            Write-Host "  FAILED  $label - $($outcome.Detail)" -ForegroundColor Red
-            $results.Add([PSCustomObject]$outcome)
-            continue
-        }
+        $result = Remove-IntuneAppVersion -Deletion $deletion
+        $outcome.Outcome = $result.Outcome
+        $outcome.Detail = $result.Detail
+        Write-AppCleanupOutcome -Outcome $result.Outcome -Label $label -Detail $result.Detail
 
-        try {
-            Remove-InteropWin32App -AppId $deletion.Id
-            $outcome.Outcome = 'Deleted'
-            $outcome.Detail = "$($removal.Removed) relationship(s) removed first"
-            Write-Host "  Deleted $label" -ForegroundColor Green
-        }
-        catch {
-            $outcome.Outcome = 'Failed'
-            $outcome.Detail = $_.Exception.Message
-            if ($removal.Removed -gt 0) {
-                $outcome.Detail += " (its $($removal.Removed) relationship(s) were already removed, so the app is now unlinked and still in Intune - re-run the cleanup)"
-            }
-            Write-Host "  FAILED  $label - $($outcome.Detail)" -ForegroundColor Red
-        }
         $results.Add([PSCustomObject]$outcome)
     }
     return @($results)

--- a/IntuneInterop.ps1
+++ b/IntuneInterop.ps1
@@ -370,6 +370,183 @@ function Get-InteropWin32AppById {
     }
 }
 
+# Internal: writes the requirement rule (architectures and minimum hardware) into a win32LobApp
+# body, or the module's defaults when the caller supplied no rule.
+function Add-InteropRequirementRule {
+    param(
+        [Parameter(Mandatory = $true)] $Body,
+        [AllowNull()] $RequirementRule
+    )
+
+    if (-not $RequirementRule) {
+        # Module defaults when no requirement rule is given
+        $Body['applicableArchitectures'] = 'x64,x86'
+        $Body['minimumSupportedWindowsRelease'] = '2H20'
+        return
+    }
+
+    $Body['minimumSupportedWindowsRelease'] = $RequirementRule['minimumSupportedWindowsRelease']
+    if ($RequirementRule['allowedArchitectures']) {
+        $Body['allowedArchitectures'] = $RequirementRule['allowedArchitectures']
+        $Body['applicableArchitectures'] = 'none'
+    }
+    else {
+        $Body['applicableArchitectures'] = $RequirementRule['applicableArchitectures']
+    }
+
+    foreach ($ruleProperty in 'minimumFreeDiskSpaceInMB', 'minimumMemoryInMB', 'minimumNumberOfProcessors', 'minimumCpuSpeedInMHz') {
+        if ($RequirementRule[$ruleProperty]) {
+            $Body[$ruleProperty] = $RequirementRule[$ruleProperty]
+        }
+    }
+}
+
+# Internal: the win32LobApp body Publish-InteropWin32App POSTs.
+# This repository always provides explicit install and uninstall command lines, which is the
+# module's 'EXE' body shape - msiInformation is never sent, matching how every app (MSI packages
+# included) has always been deployed here.
+function New-InteropWin32AppBody {
+    param(
+        [Parameter(Mandatory = $true)] [hashtable]$AppParams,
+        [Parameter(Mandatory = $true)] $AppInfo
+    )
+
+    $body = [ordered]@{
+        '@odata.type'           = '#microsoft.graph.win32LobApp'
+        'description'           = $AppParams.Description
+        'developer'             = ''
+        'displayVersion'        = $AppParams.AppVersion
+        'owner'                 = ''
+        'notes'                 = ''
+        'informationUrl'        = ''
+        'privacyInformationUrl' = ''
+        'isFeatured'            = $false
+        'displayName'           = $AppParams.DisplayName
+        'fileName'              = $AppInfo.FileName
+        'setupFilePath'         = $AppInfo.SetupFile
+        'installCommandLine'    = $AppParams.InstallCommandLine
+        'uninstallCommandLine'  = $AppParams.UninstallCommandLine
+        'installExperience'     = @{
+            'runAsAccount'          = $AppParams.InstallExperience
+            'deviceRestartBehavior' = $AppParams.RestartBehavior
+            'maxRunTimeInMinutes'   = 60
+        }
+        'publisher'             = $AppParams.Publisher
+    }
+    # Note: the module also sent 'runAs32bit = $false' here. That property does not
+    # exist on win32LobApp in the Graph schema (runAs32Bit belongs to the script
+    # detection/requirement rule types) and the service ignores it, so it is omitted.
+
+    Add-InteropRequirementRule -Body $body -RequirementRule $AppParams.RequirementRule
+
+    $body['detectionRules'] = @($AppParams.DetectionRule)
+
+    # Default return code set (module parity)
+    $body['returnCodes'] = @(
+        @{ 'returnCode' = 0; 'type' = 'success' }
+        @{ 'returnCode' = 1707; 'type' = 'success' }
+        @{ 'returnCode' = 3010; 'type' = 'softReboot' }
+        @{ 'returnCode' = 1641; 'type' = 'hardReboot' }
+        @{ 'returnCode' = 1618; 'type' = 'retry' }
+    )
+
+    if ($AppParams.Icon) {
+        $body['largeIcon'] = @{
+            'type'  = 'image/png'
+            'value' = $AppParams.Icon
+        }
+    }
+
+    return $body
+}
+
+# Internal: extracts the pre-encrypted payload out of the .intunewin package to $Destination.
+function Expand-InteropPayload {
+    param(
+        [Parameter(Mandatory = $true)] [string]$PackagePath,
+        [Parameter(Mandatory = $true)] [string]$FileName,
+        [Parameter(Mandatory = $true)] [string]$Destination
+    )
+
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($PackagePath)
+    try {
+        # Exact match, not -like: the filename comes from Detection.xml data and
+        # must never be interpreted as a wildcard pattern
+        $payloadEntry = $archive.Entries | Where-Object { $_.Name -eq "$FileName" } | Select-Object -First 1
+        if ($null -eq $payloadEntry) {
+            throw "Could not find the encrypted payload '$FileName' inside the .intunewin package"
+        }
+        [System.IO.Compression.ZipFileExtensions]::ExtractToFile($payloadEntry, $Destination, $true)
+    }
+    finally {
+        $archive.Dispose()
+    }
+}
+
+# Internal: creates the content file entry and waits for the Azure Storage SAS URI.
+# Returns @{ FilesUri; ProcessedFile }.
+function New-InteropContentFile {
+    param(
+        [Parameter(Mandatory = $true)] [string]$ContentVersionUri,
+        [Parameter(Mandatory = $true)] [string]$PackagePath,
+        [Parameter(Mandatory = $true)] [string]$PayloadPath,
+        [Parameter(Mandatory = $true)] $AppInfo
+    )
+
+    Write-Verbose 'Constructing Win32 app content file body for uploading of .intunewin file'
+    $fileBody = [ordered]@{
+        '@odata.type'   = '#microsoft.graph.mobileAppContentFile'
+        'name'          = [System.IO.Path]::GetFileName($PackagePath)
+        'size'          = [int64]$AppInfo.UnencryptedContentSize
+        'sizeEncrypted' = (Get-Item -Path $PayloadPath).Length
+        'manifest'      = $null
+        'isDependency'  = $false
+    }
+    $contentFile = Invoke-MgGraphRequest -Method POST -Uri "$ContentVersionUri/files" -Body ($fileBody | ConvertTo-Json) -ContentType 'application/json' -OutputType PSObject -ErrorAction Stop
+    if ([string]::IsNullOrEmpty($contentFile.id)) {
+        throw 'Failed to create the contentVersions files resource for the Win32 app'
+    }
+
+    $filesUri = "$ContentVersionUri/files/$($contentFile.id)"
+    Write-Verbose 'Waiting for Intune service to process contentVersions/files request'
+    $processedFile = Wait-InteropFileProcessing -Stage 'AzureStorageUriRequest' -Uri $filesUri
+    if ($processedFile.uploadState -notlike 'azureStorageUriRequestSuccess') {
+        throw "Azure Storage URI request failed with uploadState: $($processedFile.uploadState)"
+    }
+
+    return @{ FilesUri = $filesUri; ProcessedFile = $processedFile }
+}
+
+# Internal: commits the uploaded file with the encryption info the packaging tool recorded, and
+# waits for the service to process the commit.
+function Publish-InteropFileCommit {
+    param(
+        [Parameter(Mandatory = $true)] [string]$FilesUri,
+        [Parameter(Mandatory = $true)] $AppInfo
+    )
+
+    $commitBody = @{
+        'fileEncryptionInfo' = [ordered]@{
+            'encryptionKey'        = $AppInfo.EncryptionInfo.EncryptionKey
+            'macKey'               = $AppInfo.EncryptionInfo.MacKey
+            'initializationVector' = $AppInfo.EncryptionInfo.InitializationVector
+            'mac'                  = $AppInfo.EncryptionInfo.Mac
+            # Prefer what the packaging tool recorded; 'ProfileVersion1' is the
+            # only known value and doubles as the fallback (module parity)
+            'profileIdentifier'    = [string]::IsNullOrEmpty($AppInfo.EncryptionInfo.ProfileIdentifier) ? 'ProfileVersion1' : $AppInfo.EncryptionInfo.ProfileIdentifier
+            'fileDigest'           = $AppInfo.EncryptionInfo.FileDigest
+            'fileDigestAlgorithm'  = $AppInfo.EncryptionInfo.FileDigestAlgorithm
+        }
+    }
+    $null = Invoke-MgGraphRequest -Method POST -Uri "$FilesUri/commit" -Body ($commitBody | ConvertTo-Json) -ContentType 'application/json' -ErrorAction Stop
+
+    Write-Verbose 'Waiting for Intune service to process the commit file request'
+    $commitResult = Wait-InteropFileProcessing -Stage 'CommitFile' -Uri $FilesUri
+    if ($commitResult.uploadState -notlike 'commitFileSuccess') {
+        throw "Commit file request failed with uploadState: $($commitResult.uploadState)"
+    }
+}
+
 function Publish-InteropWin32App {
     <#
     .SYNOPSIS
@@ -405,75 +582,7 @@ function Publish-InteropWin32App {
     }
     $appInfo = $metadata.ApplicationInfo
 
-    # Build the win32LobApp body. This repository always provides explicit install and
-    # uninstall command lines, which is the module's 'EXE' body shape - msiInformation
-    # is never sent, matching how every app (MSI packages included) has always been
-    # deployed here.
-    $body = [ordered]@{
-        '@odata.type'           = '#microsoft.graph.win32LobApp'
-        'description'           = $AppParams.Description
-        'developer'             = ''
-        'displayVersion'        = $AppParams.AppVersion
-        'owner'                 = ''
-        'notes'                 = ''
-        'informationUrl'        = ''
-        'privacyInformationUrl' = ''
-        'isFeatured'            = $false
-        'displayName'           = $AppParams.DisplayName
-        'fileName'              = $appInfo.FileName
-        'setupFilePath'         = $appInfo.SetupFile
-        'installCommandLine'    = $AppParams.InstallCommandLine
-        'uninstallCommandLine'  = $AppParams.UninstallCommandLine
-        'installExperience'     = @{
-            'runAsAccount'          = $AppParams.InstallExperience
-            'deviceRestartBehavior' = $AppParams.RestartBehavior
-            'maxRunTimeInMinutes'   = 60
-        }
-        'publisher'             = $AppParams.Publisher
-    }
-    # Note: the module also sent 'runAs32bit = $false' here. That property does not
-    # exist on win32LobApp in the Graph schema (runAs32Bit belongs to the script
-    # detection/requirement rule types) and the service ignores it, so it is omitted.
-
-    $requirementRule = $AppParams.RequirementRule
-    if ($requirementRule) {
-        $body['minimumSupportedWindowsRelease'] = $requirementRule['minimumSupportedWindowsRelease']
-        if ($requirementRule['allowedArchitectures']) {
-            $body['allowedArchitectures'] = $requirementRule['allowedArchitectures']
-            $body['applicableArchitectures'] = 'none'
-        }
-        else {
-            $body['applicableArchitectures'] = $requirementRule['applicableArchitectures']
-        }
-        foreach ($ruleProperty in 'minimumFreeDiskSpaceInMB', 'minimumMemoryInMB', 'minimumNumberOfProcessors', 'minimumCpuSpeedInMHz') {
-            if ($requirementRule[$ruleProperty]) {
-                $body[$ruleProperty] = $requirementRule[$ruleProperty]
-            }
-        }
-    }
-    else {
-        # Module defaults when no requirement rule is given
-        $body['applicableArchitectures'] = 'x64,x86'
-        $body['minimumSupportedWindowsRelease'] = '2H20'
-    }
-
-    $body['detectionRules'] = @($AppParams.DetectionRule)
-
-    # Default return code set (module parity)
-    $body['returnCodes'] = @(
-        @{ 'returnCode' = 0; 'type' = 'success' }
-        @{ 'returnCode' = 1707; 'type' = 'success' }
-        @{ 'returnCode' = 3010; 'type' = 'softReboot' }
-        @{ 'returnCode' = 1641; 'type' = 'hardReboot' }
-        @{ 'returnCode' = 1618; 'type' = 'retry' }
-    )
-
-    if ($AppParams.Icon) {
-        $body['largeIcon'] = @{
-            'type'  = 'image/png'
-            'value' = $AppParams.Icon
-        }
-    }
+    $body = New-InteropWin32AppBody -AppParams $AppParams -AppInfo $appInfo
 
     # Create the app
     Write-Verbose 'Attempting to create Win32 app using constructed body'
@@ -496,66 +605,14 @@ function Publish-InteropWin32App {
     try {
         New-Item -ItemType Directory -Path $extractDir -Force | Out-Null
         $payloadPath = Join-Path $extractDir $appInfo.FileName
-        $archive = [System.IO.Compression.ZipFile]::OpenRead($AppParams.FilePath)
-        try {
-            # Exact match, not -like: the filename comes from Detection.xml data and
-            # must never be interpreted as a wildcard pattern
-            $payloadEntry = $archive.Entries | Where-Object { $_.Name -eq "$($appInfo.FileName)" } | Select-Object -First 1
-            if ($null -eq $payloadEntry) {
-                throw "Could not find the encrypted payload '$($appInfo.FileName)' inside the .intunewin package"
-            }
-            [System.IO.Compression.ZipFileExtensions]::ExtractToFile($payloadEntry, $payloadPath, $true)
-        }
-        finally {
-            $archive.Dispose()
-        }
+        Expand-InteropPayload -PackagePath $AppParams.FilePath -FileName $appInfo.FileName -Destination $payloadPath
 
-        # Create the content file entry and wait for the Azure Storage SAS URI
-        Write-Verbose 'Constructing Win32 app content file body for uploading of .intunewin file'
-        $fileBody = [ordered]@{
-            '@odata.type'   = '#microsoft.graph.mobileAppContentFile'
-            'name'          = [System.IO.Path]::GetFileName($AppParams.FilePath)
-            'size'          = [int64]$appInfo.UnencryptedContentSize
-            'sizeEncrypted' = (Get-Item -Path $payloadPath).Length
-            'manifest'      = $null
-            'isDependency'  = $false
-        }
-        $contentFile = Invoke-MgGraphRequest -Method POST -Uri "$appUri/microsoft.graph.win32LobApp/contentVersions/$($contentVersion.id)/files" -Body ($fileBody | ConvertTo-Json) -ContentType 'application/json' -OutputType PSObject -ErrorAction Stop
-        if ([string]::IsNullOrEmpty($contentFile.id)) {
-            throw 'Failed to create the contentVersions files resource for the Win32 app'
-        }
-
-        $filesUri = "$appUri/microsoft.graph.win32LobApp/contentVersions/$($contentVersion.id)/files/$($contentFile.id)"
-        Write-Verbose 'Waiting for Intune service to process contentVersions/files request'
-        $processedFile = Wait-InteropFileProcessing -Stage 'AzureStorageUriRequest' -Uri $filesUri
-        if ($processedFile.uploadState -notlike 'azureStorageUriRequestSuccess') {
-            throw "Azure Storage URI request failed with uploadState: $($processedFile.uploadState)"
-        }
+        $content = New-InteropContentFile -ContentVersionUri "$appUri/microsoft.graph.win32LobApp/contentVersions/$($contentVersion.id)" -PackagePath $AppParams.FilePath -PayloadPath $payloadPath -AppInfo $appInfo
 
         # Upload the payload in chunks
-        Invoke-InteropAzureBlobUpload -StorageUri $processedFile.azureStorageUri -FilePath $payloadPath -FilesUri $filesUri
+        Invoke-InteropAzureBlobUpload -StorageUri $content.ProcessedFile.azureStorageUri -FilePath $payloadPath -FilesUri $content.FilesUri
 
-        # Commit the file with the encryption info the packaging tool recorded
-        $commitBody = @{
-            'fileEncryptionInfo' = [ordered]@{
-                'encryptionKey'        = $appInfo.EncryptionInfo.EncryptionKey
-                'macKey'               = $appInfo.EncryptionInfo.MacKey
-                'initializationVector' = $appInfo.EncryptionInfo.InitializationVector
-                'mac'                  = $appInfo.EncryptionInfo.Mac
-                # Prefer what the packaging tool recorded; 'ProfileVersion1' is the
-                # only known value and doubles as the fallback (module parity)
-                'profileIdentifier'    = [string]::IsNullOrEmpty($appInfo.EncryptionInfo.ProfileIdentifier) ? 'ProfileVersion1' : $appInfo.EncryptionInfo.ProfileIdentifier
-                'fileDigest'           = $appInfo.EncryptionInfo.FileDigest
-                'fileDigestAlgorithm'  = $appInfo.EncryptionInfo.FileDigestAlgorithm
-            }
-        }
-        $null = Invoke-MgGraphRequest -Method POST -Uri "$filesUri/commit" -Body ($commitBody | ConvertTo-Json) -ContentType 'application/json' -ErrorAction Stop
-
-        Write-Verbose 'Waiting for Intune service to process the commit file request'
-        $commitResult = Wait-InteropFileProcessing -Stage 'CommitFile' -Uri $filesUri
-        if ($commitResult.uploadState -notlike 'commitFileSuccess') {
-            throw "Commit file request failed with uploadState: $($commitResult.uploadState)"
-        }
+        Publish-InteropFileCommit -FilesUri $content.FilesUri -AppInfo $appInfo
 
         # Mark the content version as committed and return the final app object
         Write-Verbose "Updating committedContentVersion property with ID '$($contentVersion.id)' for Win32 app with ID: $($app.id)"
@@ -727,6 +784,84 @@ function Wait-InteropFileProcessing {
     return $request
 }
 
+# Internal: PUTs one block of the payload, retrying transient Azure Storage failures.
+# $true when the block made it, $false when all 8 attempts failed.
+function Invoke-InteropChunkUpload {
+    param(
+        [Parameter(Mandatory = $true)] [string]$StorageUri,
+        [Parameter(Mandatory = $true)] [string]$ChunkId,
+        [Parameter(Mandatory = $true)] [byte[]]$Bytes,
+        [int]$ChunkNumber = 1,
+        [int]$ChunkCount = 1
+    )
+
+    for ($attempt = 1; $attempt -le 8; $attempt++) {
+        try {
+            $null = Invoke-WebRequest -Uri "$StorageUri&comp=block&blockid=$ChunkId" -Method Put -Headers @{ 'x-ms-blob-type' = 'BlockBlob' } -Body $Bytes -ErrorAction Stop
+            return $true
+        }
+        catch {
+            $delay = Get-Random -Minimum 7 -Maximum 30
+            Write-Warning "Failed to upload chunk $ChunkNumber of $ChunkCount (attempt $attempt of 8), retrying in $delay seconds: $($_.Exception.Message)"
+            Start-Sleep -Seconds $delay
+        }
+    }
+
+    return $false
+}
+
+# Internal: renews the Azure Storage SAS URI before it expires on long uploads. Returns the URI
+# to keep using - the renewed one, or the current one when the renewal did not work out (the
+# upload then simply runs on until Azure rejects it, which the chunk retry reports).
+function Update-InteropSasUri {
+    param(
+        [Parameter(Mandatory = $true)] [string]$StorageUri,
+        [Parameter(Mandatory = $true)] [string]$FilesUri,
+        [Parameter(Mandatory = $true)] $RenewalTimer
+    )
+
+    Write-Verbose 'SAS Uri renewal is required, attempting to renew'
+    try {
+        $null = Invoke-MgGraphRequest -Method POST -Uri "$FilesUri/renewUpload" -Body '{}' -ContentType 'application/json' -ErrorAction Stop
+        $renewed = Wait-InteropFileProcessing -Stage 'AzureStorageUriRenewal' -Uri $FilesUri -TimeoutSeconds 60
+        if ($renewed.uploadState -notlike 'azureStorageUriRenewalSuccess') {
+            Write-Warning 'SAS Uri renewal failed, continuing with the existing Uri'
+            return $StorageUri
+        }
+        $RenewalTimer.Restart()
+        return $renewed.azureStorageUri
+    }
+    catch {
+        Write-Warning "SAS Uri renewal attempt failed, continuing with the existing Uri: $($_.Exception.Message)"
+        return $StorageUri
+    }
+}
+
+# Internal: commits the uploaded blocks (PutBlockList), retrying transient failures. Throws when
+# the blob cannot be finalized - the upload is then not usable.
+function Invoke-InteropBlockListCommit {
+    param(
+        [Parameter(Mandatory = $true)] [string]$StorageUri,
+        [Parameter(Mandatory = $true)] [AllowEmptyCollection()] [array]$ChunkIds
+    )
+
+    $blockListXml = '<?xml version="1.0" encoding="utf-8"?><BlockList>' + (($ChunkIds | ForEach-Object { "<Latest>$_</Latest>" }) -join '') + '</BlockList>'
+
+    for ($attempt = 1; $attempt -le 8; $attempt++) {
+        try {
+            $null = Invoke-RestMethod -Uri "$StorageUri&comp=blocklist" -Method Put -Body $blockListXml -ContentType 'text/plain; charset=UTF-8' -ErrorAction Stop
+            return
+        }
+        catch {
+            $delay = Get-Random -Minimum 7 -Maximum 30
+            Write-Warning "Failed to finalize the blob upload (attempt $attempt of 8), retrying in $delay seconds: $($_.Exception.Message)"
+            Start-Sleep -Seconds $delay
+        }
+    }
+
+    throw 'Failed to finalize the Azure Storage blob upload after 8 attempts'
+}
+
 function Invoke-InteropAzureBlobUpload {
     <#
     .SYNOPSIS
@@ -770,61 +905,18 @@ function Invoke-InteropAzureBlobUpload {
             $currentChunk = $chunk + 1
             Write-Verbose "Uploading file to Azure Storage blob, processing chunk '$currentChunk' of '$chunkCount'"
 
-            $uploaded = $false
-            for ($attempt = 1; $attempt -le 8; $attempt++) {
-                try {
-                    $null = Invoke-WebRequest -Uri "$StorageUri&comp=block&blockid=$chunkId" -Method Put -Headers @{ 'x-ms-blob-type' = 'BlockBlob' } -Body $bytes -ErrorAction Stop
-                    $uploaded = $true
-                    break
-                }
-                catch {
-                    $delay = Get-Random -Minimum 7 -Maximum 30
-                    Write-Warning "Failed to upload chunk $currentChunk of $chunkCount (attempt $attempt of 8), retrying in $delay seconds: $($_.Exception.Message)"
-                    Start-Sleep -Seconds $delay
-                }
-            }
-            if (-not $uploaded) {
+            if (-not (Invoke-InteropChunkUpload -StorageUri $StorageUri -ChunkId $chunkId -Bytes $bytes -ChunkNumber $currentChunk -ChunkCount $chunkCount)) {
                 throw "Failed to upload chunk $currentChunk of $chunkCount after 8 attempts"
             }
 
             # Renew the SAS URI before it expires on long uploads (~7.5 minutes elapsed)
             if (($currentChunk -lt $chunkCount) -and ($sasRenewalTimer.ElapsedMilliseconds -ge 450000)) {
-                Write-Verbose 'SAS Uri renewal is required, attempting to renew'
-                try {
-                    $null = Invoke-MgGraphRequest -Method POST -Uri "$FilesUri/renewUpload" -Body '{}' -ContentType 'application/json' -ErrorAction Stop
-                    $renewed = Wait-InteropFileProcessing -Stage 'AzureStorageUriRenewal' -Uri $FilesUri -TimeoutSeconds 60
-                    if ($renewed.uploadState -like 'azureStorageUriRenewalSuccess') {
-                        $StorageUri = $renewed.azureStorageUri
-                        $sasRenewalTimer.Restart()
-                    }
-                    else {
-                        Write-Warning 'SAS Uri renewal failed, continuing with the existing Uri'
-                    }
-                }
-                catch {
-                    Write-Warning "SAS Uri renewal attempt failed, continuing with the existing Uri: $($_.Exception.Message)"
-                }
+                $StorageUri = Update-InteropSasUri -StorageUri $StorageUri -FilesUri $FilesUri -RenewalTimer $sasRenewalTimer
             }
         }
 
         # Commit the block list
-        $blockListXml = '<?xml version="1.0" encoding="utf-8"?><BlockList>' + (($chunkIds | ForEach-Object { "<Latest>$_</Latest>" }) -join '') + '</BlockList>'
-        $finalized = $false
-        for ($attempt = 1; $attempt -le 8; $attempt++) {
-            try {
-                $null = Invoke-RestMethod -Uri "$StorageUri&comp=blocklist" -Method Put -Body $blockListXml -ContentType 'text/plain; charset=UTF-8' -ErrorAction Stop
-                $finalized = $true
-                break
-            }
-            catch {
-                $delay = Get-Random -Minimum 7 -Maximum 30
-                Write-Warning "Failed to finalize the blob upload (attempt $attempt of 8), retrying in $delay seconds: $($_.Exception.Message)"
-                Start-Sleep -Seconds $delay
-            }
-        }
-        if (-not $finalized) {
-            throw 'Failed to finalize the Azure Storage blob upload after 8 attempts'
-        }
+        Invoke-InteropBlockListCommit -StorageUri $StorageUri -ChunkIds $chunkIds
     }
     finally {
         $reader.Dispose()
@@ -1073,7 +1165,8 @@ function Get-InteropErrorMessage {
                 }
             }
             catch {
-                # not JSON - use the raw details
+                # not JSON (an HTML error page, a truncated body) - keep the raw details
+                Write-Verbose "Graph error body is not JSON, using the raw details: $_"
             }
         }
         $message = "$message | $details"

--- a/IntuneInventory.ps1
+++ b/IntuneInventory.ps1
@@ -8,6 +8,150 @@
 
 . (Join-Path $PSScriptRoot "AppInventory.ps1")
 
+# The tenant's Win32 apps, or - with -OnlyFamilies - just the apps of those families (plus the
+# unmanaged ones with -IncludeUnmanaged).
+function Get-IntuneAppInventoryList {
+    param(
+        [Parameter(Mandatory = $true)] [AllowEmptyCollection()] [array]$Families,
+        [string[]]$OnlyFamilies,
+        [bool]$IncludeUnmanaged = $false
+    )
+
+    if (-not $OnlyFamilies) {
+        $apps = @(Get-InteropWin32App)
+        Write-Host "  $($apps.Count) Win32 app(s) in tenant" -ForegroundColor Gray
+        return ,$apps
+    }
+
+    # Classify on the list items' display names so only the selected apps are fetched in full.
+    # Deliberately a plain script block: it is only ever invoked from inside Get-InteropWin32App,
+    # i.e. from a scope below this one, so $Families/$OnlyFamilies/$IncludeUnmanaged resolve
+    # through PowerShell's dynamic scoping. Do NOT turn it into a closure (.GetNewClosure()):
+    # a closure is bound to a new dynamic module whose command lookup skips the scope the
+    # scripts dot-source into, and Resolve-AppFamily is then not found (observed:
+    # CommandNotFoundException in both the tests and a script-scope run).
+    $familyFilter = {
+        param($displayName)
+        $family = Resolve-AppFamily -DisplayName "$displayName" -Families $Families
+        if ($family) { $OnlyFamilies -contains $family.AppConfigName } else { [bool]$IncludeUnmanaged }
+    }
+    $apps = @(Get-InteropWin32App -DisplayNameFilter $familyFilter)
+    Write-Host "  $($apps.Count) Win32 app(s) of $($OnlyFamilies -join ', ')$(if ($IncludeUnmanaged) { ' (plus unmanaged apps)' }) in tenant" -ForegroundColor Gray
+    return ,$apps
+}
+
+# Adds the apps the tenant list does not carry yet (the mobileApps list lags a creation by a few
+# seconds; the per-ID GET does not). An app that cannot be read directly is warned about and
+# skipped - the caller works with what is there.
+function Add-IntuneEnsuredApp {
+    param(
+        [Parameter(Mandatory = $true)] [AllowEmptyCollection()] [array]$Apps,
+        [string[]]$EnsureAppIds
+    )
+
+    $result = @($Apps)
+    foreach ($ensureId in @($EnsureAppIds | Where-Object { $_ })) {
+        if (@($result | Where-Object { "$($_.id)" -eq $ensureId }).Count -gt 0) { continue }
+        try {
+            $late = Get-InteropWin32AppById -AppId $ensureId
+            if ($null -ne $late) {
+                $result += $late
+                Write-Host "  + $($late.displayName) (not in the tenant list yet - fetched directly)" -ForegroundColor Gray
+            }
+        }
+        catch {
+            Write-Host "  Warning: app '$ensureId' could not be read directly: $($_.Exception.Message)" -ForegroundColor Yellow
+        }
+    }
+
+    return ,$result
+}
+
+# Group name resolution is best-effort: only when the Groups module is already available.
+function Initialize-GroupNameResolution {
+    param([bool]$ResolveGroupNames = $false)
+
+    if (-not ($ResolveGroupNames -and (Get-Module -ListAvailable -Name Microsoft.Graph.Groups))) {
+        return $false
+    }
+
+    try {
+        Import-Module Microsoft.Graph.Groups -ErrorAction Stop
+        return $true
+    }
+    catch {
+        Write-Host "  Microsoft.Graph.Groups could not be loaded - group assignments are reported by id" -ForegroundColor Yellow
+        return $false
+    }
+}
+
+# Install counts come from one tenant-wide report (getAppsInstallSummaryReport) rather than one
+# request per app. If the report fails, the inventory still works - without counts ($null).
+function Get-IntuneInstallSummaryReport {
+    try {
+        $installSummaries = Get-InteropAppInstallSummaryReport
+        Write-Host "  Read install summaries for $($installSummaries.Count) app(s)" -ForegroundColor Gray
+        return $installSummaries
+    }
+    catch {
+        Write-Host "  Warning: could not read the install summary report, the inventory will not include install counts: $($_.Exception.Message)" -ForegroundColor Yellow
+        return $null
+    }
+}
+
+# One app's assignments, or $null when they could not be read - never an empty set, which is a
+# successful read of an unassigned app.
+function Read-IntuneAppAssignmentDetail {
+    param([Parameter(Mandatory = $true)] $App)
+
+    try {
+        $assignments = @(Get-InteropAppAssignmentDetail -AppId $App.id)
+        return ,$assignments
+    }
+    catch {
+        Write-Host "  Warning: could not read assignments for '$($App.displayName)': $($_.Exception.Message)" -ForegroundColor Yellow
+        return $null
+    }
+}
+
+# One app's relationships. $null (not an empty set) on failure: the record is marked
+# RelationshipsUnavailable and the analysis suppresses its deletion, because it might be a
+# dependency target we cannot see.
+function Read-IntuneAppRelationshipDetail {
+    param([Parameter(Mandatory = $true)] $App)
+
+    try {
+        $relationships = @(Get-InteropAppRelationship -AppId $App.id)
+        return ,$relationships
+    }
+    catch {
+        Write-Host "  Warning: could not read relationships for '$($App.displayName)': $($_.Exception.Message)" -ForegroundColor Yellow
+        return $null
+    }
+}
+
+# Resolves the display name of every group these assignments target that the cache does not know
+# yet (a group that cannot be read is cached as $null, so it is not asked for again).
+function Update-AppGroupNameCache {
+    param(
+        [Parameter(Mandatory = $true)] [hashtable]$GroupNames,
+        [AllowNull()] $Assignments,
+        [bool]$CanResolveGroups = $false
+    )
+
+    if (-not $CanResolveGroups) { return }
+
+    foreach ($assignment in @($Assignments)) {
+        if (-not $assignment.GroupId -or $GroupNames.ContainsKey($assignment.GroupId)) { continue }
+        try {
+            $GroupNames[$assignment.GroupId] = (Get-MgGroup -GroupId $assignment.GroupId -Property displayName -ErrorAction Stop).DisplayName
+        }
+        catch {
+            $GroupNames[$assignment.GroupId] = $null
+        }
+    }
+}
+
 function Read-IntuneAppInventory {
     <#
     .SYNOPSIS
@@ -51,66 +195,18 @@ function Read-IntuneAppInventory {
         [switch]$ResolveGroupNames
     )
 
-    if ($OnlyFamilies) {
-        # Classify on the list items' display names so only the selected apps are fetched in full.
-        # Deliberately a plain script block: it is only ever invoked from inside Get-InteropWin32App,
-        # i.e. from a scope below this one, so $Families/$OnlyFamilies/$IncludeUnmanaged resolve
-        # through PowerShell's dynamic scoping. Do NOT turn it into a closure (.GetNewClosure()):
-        # a closure is bound to a new dynamic module whose command lookup skips the scope the
-        # scripts dot-source into, and Resolve-AppFamily is then not found (observed:
-        # CommandNotFoundException in both the tests and a script-scope run).
-        $familyFilter = {
-            param($displayName)
-            $family = Resolve-AppFamily -DisplayName "$displayName" -Families $Families
-            if ($family) { $OnlyFamilies -contains $family.AppConfigName } else { [bool]$IncludeUnmanaged }
-        }
-        $apps = @(Get-InteropWin32App -DisplayNameFilter $familyFilter)
-        Write-Host "  $($apps.Count) Win32 app(s) of $($OnlyFamilies -join ', ')$(if ($IncludeUnmanaged) { ' (plus unmanaged apps)' }) in tenant" -ForegroundColor Gray
-    }
-    else {
-        $apps = @(Get-InteropWin32App)
-        Write-Host "  $($apps.Count) Win32 app(s) in tenant" -ForegroundColor Gray
-    }
-
-    foreach ($ensureId in @($EnsureAppIds | Where-Object { $_ })) {
-        if (@($apps | Where-Object { "$($_.id)" -eq $ensureId }).Count -gt 0) { continue }
-        try {
-            $late = Get-InteropWin32AppById -AppId $ensureId
-            if ($null -ne $late) {
-                $apps += $late
-                Write-Host "  + $($late.displayName) (not in the tenant list yet - fetched directly)" -ForegroundColor Gray
-            }
-        }
-        catch {
-            Write-Host "  Warning: app '$ensureId' could not be read directly: $($_.Exception.Message)" -ForegroundColor Yellow
-        }
-    }
+    # No @() around these calls: both return the array as one object (,$array), which @() would
+    # wrap a second time
+    $apps = Get-IntuneAppInventoryList -Families $Families -OnlyFamilies $OnlyFamilies -IncludeUnmanaged ([bool]$IncludeUnmanaged)
+    $apps = Add-IntuneEnsuredApp -Apps $apps -EnsureAppIds $EnsureAppIds
     $appCount = $apps.Count
 
-    # Group name resolution is best-effort: only when the Groups module is already available
     $groupNames = @{}
-    $canResolveGroups = $false
-    if ($ResolveGroupNames -and (Get-Module -ListAvailable -Name Microsoft.Graph.Groups)) {
-        try {
-            Import-Module Microsoft.Graph.Groups -ErrorAction Stop
-            $canResolveGroups = $true
-        }
-        catch {
-            Write-Host "  Microsoft.Graph.Groups could not be loaded - group assignments are reported by id" -ForegroundColor Yellow
-        }
-    }
+    $canResolveGroups = Initialize-GroupNameResolution -ResolveGroupNames ([bool]$ResolveGroupNames)
 
-    # Install counts come from one tenant-wide report (getAppsInstallSummaryReport) rather than
-    # one request per app. If the report fails, the inventory still works - without counts.
     $installSummaries = $null
     if ($IncludeInstallSummary) {
-        try {
-            $installSummaries = Get-InteropAppInstallSummaryReport
-            Write-Host "  Read install summaries for $($installSummaries.Count) app(s)" -ForegroundColor Gray
-        }
-        catch {
-            Write-Host "  Warning: could not read the install summary report, the inventory will not include install counts: $($_.Exception.Message)" -ForegroundColor Yellow
-        }
+        $installSummaries = Get-IntuneInstallSummaryReport
     }
 
     $records = [System.Collections.Generic.List[object]]::new()
@@ -119,34 +215,10 @@ function Read-IntuneAppInventory {
         $index++
         Write-Progress -Activity 'Reading app details' -Status "$index of $($apps.Count): $($app.displayName)" -PercentComplete (100 * $index / [math]::Max($apps.Count, 1))
 
-        $assignments = $null
-        try {
-            $assignments = @(Get-InteropAppAssignmentDetail -AppId $app.id)
-        }
-        catch {
-            Write-Host "  Warning: could not read assignments for '$($app.displayName)': $($_.Exception.Message)" -ForegroundColor Yellow
-        }
+        $assignments = Read-IntuneAppAssignmentDetail -App $app
+        Update-AppGroupNameCache -GroupNames $groupNames -Assignments $assignments -CanResolveGroups $canResolveGroups
 
-        foreach ($assignment in @($assignments)) {
-            if ($canResolveGroups -and $assignment.GroupId -and -not $groupNames.ContainsKey($assignment.GroupId)) {
-                try {
-                    $groupNames[$assignment.GroupId] = (Get-MgGroup -GroupId $assignment.GroupId -Property displayName -ErrorAction Stop).DisplayName
-                }
-                catch {
-                    $groupNames[$assignment.GroupId] = $null
-                }
-            }
-        }
-
-        # $null (not an empty set) on failure: the record is marked RelationshipsUnavailable and
-        # the analysis suppresses its deletion, because it might be a dependency target we cannot see.
-        $relationships = $null
-        try {
-            $relationships = @(Get-InteropAppRelationship -AppId $app.id)
-        }
-        catch {
-            Write-Host "  Warning: could not read relationships for '$($app.displayName)': $($_.Exception.Message)" -ForegroundColor Yellow
-        }
+        $relationships = Read-IntuneAppRelationshipDetail -App $app
 
         # $null check, not truthiness: an empty (but successfully read) report is a hashtable
         # that evaluates to $false

--- a/SharedFunctions.ps1
+++ b/SharedFunctions.ps1
@@ -155,6 +155,83 @@ function Get-IntuneAppVersion {
 
 #endregion
 
+# Releases a COM object if it is still there. Releasing can only fail if it is already gone -
+# nothing to recover from, and it must never mask the result (or the error) of the work that ran
+# before the finally block.
+function Remove-ComReference {
+    param(
+        [AllowNull()] $ComObject,
+        [string]$Description = 'COM'
+    )
+
+    if ($null -eq $ComObject) { return }
+    try { [System.Runtime.InteropServices.Marshal]::ReleaseComObject($ComObject) | Out-Null }
+    catch { Write-Verbose "Releasing the $Description COM object failed: $_" }
+}
+
+# ProductVersion straight out of the MSI database via the WindowsInstaller COM object (reliable
+# on all PS versions). $null when the file is not readable as an MSI or carries no version.
+function Get-MsiProductVersion {
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$FilePath
+    )
+
+    $dbObject = $null
+    $viewObject = $null
+    try {
+        $msiInstaller = New-Object -ComObject WindowsInstaller.Installer
+        $dbObject = $msiInstaller.OpenDatabase($FilePath, 0)
+        $viewObject = $dbObject.OpenView("SELECT Value FROM Property WHERE Property = 'ProductVersion'")
+        [void]$viewObject.Execute()
+        $record = $viewObject.Fetch()
+        if (-not $record) { return $null }
+
+        $ver = $record.StringData(1)
+        if ([string]::IsNullOrWhiteSpace($ver)) { return $null }
+        return $ver
+    }
+    catch {
+        Write-Verbose "MSI COM version extraction failed: $_"
+        return $null
+    }
+    finally {
+        Remove-ComReference -ComObject $viewObject -Description 'MSI view'
+        Remove-ComReference -ComObject $dbObject -Description 'MSI database'
+    }
+}
+
+# Version from Get-AppLockerFileInformation, which PS 7 loads through the Windows compatibility
+# session. Works for both MSI and EXE. $null when nothing usable comes back.
+function Get-AppLockerFileVersion {
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$FilePath
+    )
+
+    try {
+        $info = Get-AppLockerFileInformation -Path $FilePath -ErrorAction Stop
+        $pub = $info.Publisher
+        if ($null -eq $pub) { return $null }
+
+        # The compat session usually returns Publisher as a string on PS 7, but the
+        # shape isn't guaranteed across Windows builds - handle both.
+        if ($pub -is [string]) {
+            # Format: "PUBLISHER\PRODUCT\BINARY,VERSION"
+            if ($pub -match ',(\d+[\d\.]+)') { return $matches[1] }
+            return $null
+        }
+
+        $bv = $pub.BinaryVersion
+        if ($null -ne $bv) { return $bv.ToString() }
+    }
+    catch {
+        Write-Verbose "AppLocker version extraction failed: $_"
+    }
+
+    return $null
+}
+
 # Function to extract version from an installer file
 # For MSI files, queries the MSI database directly via the WindowsInstaller COM object.
 # For EXE files, falls back to Get-AppLockerFileInformation, which PS 7 loads through
@@ -167,57 +244,12 @@ function Get-InstallerVersion {
 
     $extension = [System.IO.Path]::GetExtension($FilePath).ToLower()
 
-    # MSI: query ProductVersion from the MSI database (reliable on all PS versions)
     if ($extension -eq '.msi') {
-        $dbObject = $null
-        $viewObject = $null
-        try {
-            $msiInstaller = New-Object -ComObject WindowsInstaller.Installer
-            $dbObject = $msiInstaller.OpenDatabase($FilePath, 0)
-            $viewObject = $dbObject.OpenView("SELECT Value FROM Property WHERE Property = 'ProductVersion'")
-            [void]$viewObject.Execute()
-            $record = $viewObject.Fetch()
-            if ($record) {
-                $ver = $record.StringData(1)
-                if (-not [string]::IsNullOrWhiteSpace($ver)) {
-                    return $ver
-                }
-            }
-        }
-        catch {
-            Write-Verbose "MSI COM version extraction failed: $_"
-        }
-        finally {
-            if ($null -ne $viewObject) { try { [System.Runtime.InteropServices.Marshal]::ReleaseComObject($viewObject) | Out-Null } catch {} }
-            if ($null -ne $dbObject)   { try { [System.Runtime.InteropServices.Marshal]::ReleaseComObject($dbObject)   | Out-Null } catch {} }
-        }
+        $msiVersion = Get-MsiProductVersion -FilePath $FilePath
+        if ($msiVersion) { return $msiVersion }
     }
 
-    # Fallback: Get-AppLockerFileInformation (works for both MSI and EXE)
-    try {
-        $info = Get-AppLockerFileInformation -Path $FilePath -ErrorAction Stop
-        $pub = $info.Publisher
-
-        # The compat session usually returns Publisher as a string on PS 7, but the
-        # shape isn't guaranteed across Windows builds - handle both.
-        if ($null -ne $pub -and $pub -is [string]) {
-            # Format: "PUBLISHER\PRODUCT\BINARY,VERSION"
-            if ($pub -match ',(\d+[\d\.]+)') {
-                return $matches[1]
-            }
-        }
-        elseif ($null -ne $pub) {
-            $bv = $pub.BinaryVersion
-            if ($null -ne $bv) {
-                return $bv.ToString()
-            }
-        }
-    }
-    catch {
-        Write-Verbose "AppLocker version extraction failed: $_"
-    }
-
-    return $null
+    return Get-AppLockerFileVersion -FilePath $FilePath
 }
 
 # Function to record a successfully downloaded version in AppVersions.json.
@@ -343,6 +375,81 @@ function Test-VersionExists {
     return $false
 }
 
+# The file's SHA-256 against the pin from AppConfig or a winget manifest. Fails closed: a
+# malformed pin, an unreadable file or a mismatch are all $false.
+function Test-FileSha256 {
+    param(
+        [string]$FilePath,
+        [string]$ExpectedSha256
+    )
+
+    # Normalize: strip whitespace, uppercase, validate 64 hex chars
+    $normalizedHash = ($ExpectedSha256 -replace '\s','').ToUpperInvariant()
+    if ($normalizedHash.Length -ne 64 -or $normalizedHash -notmatch '^[0-9A-F]{64}$') {
+        Write-Host "Integrity check FAILED: ExpectedSha256 is not a valid 64-character hex string." -ForegroundColor Red
+        Write-Host "  Received: $ExpectedSha256" -ForegroundColor Red
+        return $false
+    }
+
+    try {
+        $actualHash = (Get-FileHash -Path $FilePath -Algorithm SHA256 -ErrorAction Stop).Hash
+    }
+    catch {
+        Write-Host "Integrity check FAILED: unable to compute SHA-256 for $(Split-Path $FilePath -Leaf)" -ForegroundColor Red
+        Write-Host "  Error: $($_.Exception.Message)" -ForegroundColor Red
+        return $false
+    }
+
+    if ($actualHash -ne $normalizedHash) {
+        Write-Host "Integrity check FAILED: SHA-256 mismatch for $(Split-Path $FilePath -Leaf)" -ForegroundColor Red
+        Write-Host "  Expected: $normalizedHash" -ForegroundColor Red
+        Write-Host "  Actual:   $actualHash" -ForegroundColor Red
+        return $false
+    }
+
+    Write-Host "Integrity check passed: SHA-256 verified." -ForegroundColor Green
+    return $true
+}
+
+# The file's Authenticode signature, and - when the app declares one - that the signing
+# certificate's subject contains the expected publisher (substring, case-insensitive).
+function Test-FileAuthenticodeSignature {
+    param(
+        [string]$FilePath,
+        [string]$ExpectedPublisher
+    )
+
+    try {
+        $signature = Get-AuthenticodeSignature -FilePath $FilePath -ErrorAction Stop
+    }
+    catch {
+        Write-Host "Integrity check FAILED: unable to verify Authenticode signature for $(Split-Path $FilePath -Leaf)" -ForegroundColor Red
+        Write-Host "  Error: $($_.Exception.Message)" -ForegroundColor Red
+        return $false
+    }
+
+    if ($signature.Status -ne 'Valid') {
+        Write-Host "Integrity check FAILED: Authenticode signature status is '$($signature.Status)' for $(Split-Path $FilePath -Leaf)" -ForegroundColor Red
+        return $false
+    }
+
+    if (-not $ExpectedPublisher) {
+        Write-Host "Integrity check passed: valid Authenticode signature." -ForegroundColor Green
+        return $true
+    }
+
+    $subject = $signature.SignerCertificate.Subject
+    if (-not $subject -or $subject.IndexOf($ExpectedPublisher, [System.StringComparison]::OrdinalIgnoreCase) -lt 0) {
+        Write-Host "Integrity check FAILED: publisher mismatch for $(Split-Path $FilePath -Leaf)" -ForegroundColor Red
+        Write-Host "  Expected publisher containing: $ExpectedPublisher" -ForegroundColor Red
+        Write-Host "  Actual certificate subject:    $subject" -ForegroundColor Red
+        return $false
+    }
+
+    Write-Host "Integrity check passed: valid signature from '$ExpectedPublisher'." -ForegroundColor Green
+    return $true
+}
+
 # Function to verify integrity of a downloaded installer file.
 # Checks SHA-256 hash (if provided) or Authenticode signature + optional publisher match.
 # Returns $true if the file passes verification, $false otherwise (fail closed).
@@ -359,70 +466,51 @@ function Test-DownloadedFileIntegrity {
         return $false
     }
 
-    # SHA-256 takes precedence — if provided, Authenticode checks are intentionally skipped
+    # SHA-256 takes precedence - if provided, Authenticode checks are intentionally skipped
     # because an explicit hash pins the exact binary content (stronger than signature alone).
     if ($ExpectedSha256) {
-        # Normalize: strip whitespace, uppercase, validate 64 hex chars
-        $normalizedHash = ($ExpectedSha256 -replace '\s','').ToUpperInvariant()
-        if ($normalizedHash.Length -ne 64 -or $normalizedHash -notmatch '^[0-9A-F]{64}$') {
-            Write-Host "Integrity check FAILED: ExpectedSha256 is not a valid 64-character hex string." -ForegroundColor Red
-            Write-Host "  Received: $ExpectedSha256" -ForegroundColor Red
-            return $false
-        }
-        try {
-            $actualHash = (Get-FileHash -Path $FilePath -Algorithm SHA256 -ErrorAction Stop).Hash
-            if ($actualHash -ne $normalizedHash) {
-                Write-Host "Integrity check FAILED: SHA-256 mismatch for $(Split-Path $FilePath -Leaf)" -ForegroundColor Red
-                Write-Host "  Expected: $normalizedHash" -ForegroundColor Red
-                Write-Host "  Actual:   $actualHash" -ForegroundColor Red
-                return $false
-            }
-            Write-Host "Integrity check passed: SHA-256 verified." -ForegroundColor Green
-            return $true
-        }
-        catch {
-            Write-Host "Integrity check FAILED: unable to compute SHA-256 for $(Split-Path $FilePath -Leaf)" -ForegroundColor Red
-            Write-Host "  Error: $($_.Exception.Message)" -ForegroundColor Red
-            return $false
-        }
+        return Test-FileSha256 -FilePath $FilePath -ExpectedSha256 $ExpectedSha256
     }
 
-    # Authenticode signature check (default path)
     if ($EnforceSignatureCheck) {
-        try {
-            $signature = Get-AuthenticodeSignature -FilePath $FilePath -ErrorAction Stop
-        }
-        catch {
-            Write-Host "Integrity check FAILED: unable to verify Authenticode signature for $(Split-Path $FilePath -Leaf)" -ForegroundColor Red
-            Write-Host "  Error: $($_.Exception.Message)" -ForegroundColor Red
-            return $false
-        }
-
-        if ($signature.Status -ne 'Valid') {
-            Write-Host "Integrity check FAILED: Authenticode signature status is '$($signature.Status)' for $(Split-Path $FilePath -Leaf)" -ForegroundColor Red
-            return $false
-        }
-
-        # Publisher match (substring, case-insensitive)
-        if ($ExpectedPublisher) {
-            $subject = $signature.SignerCertificate.Subject
-            if (-not $subject -or $subject.IndexOf($ExpectedPublisher, [System.StringComparison]::OrdinalIgnoreCase) -lt 0) {
-                Write-Host "Integrity check FAILED: publisher mismatch for $(Split-Path $FilePath -Leaf)" -ForegroundColor Red
-                Write-Host "  Expected publisher containing: $ExpectedPublisher" -ForegroundColor Red
-                Write-Host "  Actual certificate subject:    $subject" -ForegroundColor Red
-                return $false
-            }
-            Write-Host "Integrity check passed: valid signature from '$ExpectedPublisher'." -ForegroundColor Green
-        }
-        else {
-            Write-Host "Integrity check passed: valid Authenticode signature." -ForegroundColor Green
-        }
-        return $true
+        return Test-FileAuthenticodeSignature -FilePath $FilePath -ExpectedPublisher $ExpectedPublisher
     }
 
     # Signature enforcement explicitly disabled (AllowUnsignedInstaller = $true)
     Write-Host "Integrity check skipped: signature enforcement disabled for this app." -ForegroundColor Yellow
     return $true
+}
+
+# Records one "Key: value" pair of a winget manifest, ignoring keys the resolver does not
+# consume and empty values. -KeepExisting leaves a key an installer entry already carries
+# (its own "- Key:" line wins over the indented ones that follow).
+function Set-WingetManifestField {
+    param(
+        [Parameter(Mandatory=$true)] [hashtable]$Target,
+        [Parameter(Mandatory=$true)] [string]$Key,
+        [AllowEmptyString()] [string]$Value,
+        [Parameter(Mandatory=$true)] [string[]]$WantedKeys,
+        [switch]$KeepExisting
+    )
+
+    $trimmed = $Value.Trim("'`"")
+    if ($Key -notin $WantedKeys -or -not $trimmed) { return }
+    if ($KeepExisting -and $Target.ContainsKey($Key)) { return }
+
+    $Target[$Key] = $trimmed
+}
+
+# Adds the installer entry that was being read to the collected ones. An entry that carries no
+# key the resolver consumes is dropped (an empty hashtable is falsy), which is what the parser
+# did before the entries became a function argument.
+function Close-WingetInstallerEntry {
+    param(
+        [AllowEmptyCollection()] [array]$Installers = @(),
+        [AllowNull()] $Current
+    )
+
+    if (-not $Current) { return ,$Installers }
+    return ,($Installers + $Current)
 }
 
 # Minimal parser for winget installer manifests (<PackageId>.installer.yaml).
@@ -448,27 +536,192 @@ function ConvertFrom-WingetInstallerManifest {
 
         if ($line -match '^- ([A-Za-z][A-Za-z0-9]*):\s*(.*?)\s*$') {
             # New installer entry
-            if ($current) { $installers += $current }
+            $installers = Close-WingetInstallerEntry -Installers $installers -Current $current
             $current = @{}
-            $key = $matches[1]; $value = $matches[2].Trim("'`"")
-            if ($key -in $wantedKeys -and $value) { $current[$key] = $value }
+            Set-WingetManifestField -Target $current -Key $matches[1] -Value $matches[2] -WantedKeys $wantedKeys
+            continue
         }
-        elseif ($current -and $line -match '^  ([A-Za-z][A-Za-z0-9]*):\s*(.*?)\s*$') {
-            # Key inside the current installer entry (exactly two spaces - deeper
-            # indents belong to nested structures like AppsAndFeaturesEntries)
-            $key = $matches[1]; $value = $matches[2].Trim("'`"")
-            if ($key -in $wantedKeys -and $value -and -not $current.ContainsKey($key)) { $current[$key] = $value }
+
+        # Key inside the current installer entry (exactly two spaces - deeper
+        # indents belong to nested structures like AppsAndFeaturesEntries)
+        if ($current -and $line -match '^  ([A-Za-z][A-Za-z0-9]*):\s*(.*?)\s*$') {
+            Set-WingetManifestField -Target $current -Key $matches[1] -Value $matches[2] -WantedKeys $wantedKeys -KeepExisting
+            continue
         }
-        elseif ($line -match '^([A-Za-z][A-Za-z0-9]*):\s*(.*?)\s*$') {
-            # Root-level key: a default that installer entries inherit
-            if ($current) { $installers += $current; $current = $null }
-            $key = $matches[1]; $value = $matches[2].Trim("'`"")
-            if ($key -in $wantedKeys -and $value) { $defaults[$key] = $value }
+
+        # Root-level key: a default that installer entries inherit
+        if ($line -match '^([A-Za-z][A-Za-z0-9]*):\s*(.*?)\s*$') {
+            $installers = Close-WingetInstallerEntry -Installers $installers -Current $current
+            $current = $null
+            Set-WingetManifestField -Target $defaults -Key $matches[1] -Value $matches[2] -WantedKeys $wantedKeys
         }
     }
-    if ($current) { $installers += $current }
+    $installers = Close-WingetInstallerEntry -Installers $installers -Current $current
 
     return @{ Defaults = $defaults; Installers = $installers }
+}
+
+# The usable entries of a download-URL allowlist. A usable prefix must be an absolute https://
+# URL ending in '/', so a StartsWith match can never cross an authority boundary
+# ("https://vendor.example" must not match "https://vendor.example.evil.com/").
+function Select-WingetAllowedPrefix {
+    param([AllowNull()] [string[]]$AllowedUrlPrefixes)
+
+    return @($AllowedUrlPrefixes | Where-Object {
+        if ([string]::IsNullOrWhiteSpace($_)) { return $false }
+        $prefixUri = $null
+        [System.Uri]::TryCreate($_, [System.UriKind]::Absolute, [ref]$prefixUri) -and
+            $prefixUri.Scheme -eq 'https' -and $_.EndsWith('/')
+    })
+}
+
+# The newest published version of a package: the highest manifest directory name that parses as
+# [version] (tags like "Nightly" are skipped). $null when the listing fails or holds none.
+function Get-WingetLatestVersion {
+    param(
+        [Parameter(Mandatory=$true)] [string]$PackageId,
+        [Parameter(Mandatory=$true)] [string]$ManifestRoot
+    )
+
+    try {
+        $listing = Invoke-RestMethod -Uri "https://api.github.com/repos/microsoft/winget-pkgs/contents/$ManifestRoot" -ErrorAction Stop
+    }
+    catch {
+        Write-Host "Winget lookup FAILED: could not list versions for '$PackageId': $($_.Exception.Message)" -ForegroundColor Red
+        return $null
+    }
+
+    $versions = foreach ($item in $listing) {
+        if ($item.type -ne 'dir') { continue }
+        $parsed = $null
+        if ([version]::TryParse($item.name, [ref]$parsed)) {
+            [PSCustomObject]@{ Name = $item.name; Version = $parsed }
+        }
+    }
+
+    $latest = $versions | Sort-Object Version -Descending | Select-Object -First 1
+    if (-not $latest) {
+        Write-Host "Winget lookup FAILED: no parseable versions found for '$PackageId'" -ForegroundColor Red
+        return $null
+    }
+    return $latest
+}
+
+# The parsed installer manifest of one version. The manifest must describe the version whose
+# directory it lives in - a disagreement means a raced listing or a manipulated manifest, and
+# either way the bundle is not the "version + URL + hash" unit we claim to verify.
+function Get-WingetInstallerManifest {
+    param(
+        [Parameter(Mandatory=$true)] [string]$PackageId,
+        [Parameter(Mandatory=$true)] [string]$ManifestRoot,
+        [Parameter(Mandatory=$true)] [string]$Version
+    )
+
+    try {
+        $yaml = Invoke-RestMethod -Uri "https://raw.githubusercontent.com/microsoft/winget-pkgs/master/$ManifestRoot/$Version/$PackageId.installer.yaml" -ErrorAction Stop
+    }
+    catch {
+        Write-Host "Winget lookup FAILED: could not fetch installer manifest for '$PackageId' $($Version): $($_.Exception.Message)" -ForegroundColor Red
+        return $null
+    }
+
+    $manifest = ConvertFrom-WingetInstallerManifest -Yaml $yaml
+
+    $declaredVersion = $manifest.Defaults['PackageVersion']
+    if ($declaredVersion -and $declaredVersion -ne $Version) {
+        Write-Host "Winget lookup FAILED: manifest in directory '$Version' declares PackageVersion '$declaredVersion' for '$PackageId'" -ForegroundColor Red
+        return $null
+    }
+
+    return $manifest
+}
+
+# The one installer entry matching the requested architecture and installer type, as
+# @{ Url; Sha256 }. Anything ambiguous or unusable - no single match, a missing URL or hash, a
+# hash that is not 64 hex chars - is $null, which the caller turns into "skip this app".
+function Select-WingetInstallerEntry {
+    param(
+        [Parameter(Mandatory=$true)] [hashtable]$Manifest,
+        [Parameter(Mandatory=$true)] [string]$PackageId,
+        [Parameter(Mandatory=$true)] [string]$Version,
+        [string]$Architecture = 'x64',
+        [string]$InstallerType
+    )
+
+    $candidates = @($Manifest.Installers | Where-Object {
+        $arch = if ($_.ContainsKey('Architecture')) { $_.Architecture } else { $Manifest.Defaults['Architecture'] }
+        $type = if ($_.ContainsKey('InstallerType')) { $_.InstallerType } else { $Manifest.Defaults['InstallerType'] }
+        ($arch -eq $Architecture) -and (-not $InstallerType -or $type -eq $InstallerType)
+    })
+
+    if ($candidates.Count -ne 1) {
+        Write-Host "Winget lookup FAILED: expected exactly 1 installer entry for '$PackageId' $Version ($Architecture/$InstallerType), found $($candidates.Count)" -ForegroundColor Red
+        return $null
+    }
+
+    $url = $candidates[0]['InstallerUrl']
+    $sha256 = "$($candidates[0]['InstallerSha256'])".Trim()
+    if (-not $url -or -not $sha256) {
+        Write-Host "Winget lookup FAILED: installer entry for '$PackageId' $Version is missing InstallerUrl or InstallerSha256" -ForegroundColor Red
+        return $null
+    }
+
+    # Downstream verification would reject a malformed pin anyway (fail closed), but
+    # refusing here avoids downloading an installer that can never verify
+    if ($sha256 -notmatch '^[0-9A-Fa-f]{64}$') {
+        Write-Host "Winget lookup FAILED: InstallerSha256 for '$PackageId' $Version is not a 64-character hex hash" -ForegroundColor Red
+        return $null
+    }
+
+    return @{ Url = $url; Sha256 = $sha256 }
+}
+
+# The canonical download URL and its file name, as @{ Url; Filename } - or $null when the
+# manifest's InstallerUrl is not an allowed HTTPS URL ending in a usable file name.
+function Resolve-WingetInstallerUrl {
+    param(
+        [Parameter(Mandatory=$true)] [string]$Url,
+        [Parameter(Mandatory=$true)] [string[]]$ValidPrefixes,
+        [Parameter(Mandatory=$true)] [string]$PackageId,
+        [Parameter(Mandatory=$true)] [string]$Version
+    )
+
+    # Canonicalize before the allowlist check and use the canonical form from here on:
+    # System.Uri compacts dot segments (escaped or not), so a raw-string prefix match on
+    # "https://host/allowed/../attacker/..." would pass while the request actually goes
+    # elsewhere. The canonical AbsoluteUri is what the HTTP client will really fetch.
+    $parsedUri = $null
+    if (-not [System.Uri]::TryCreate($Url, [System.UriKind]::Absolute, [ref]$parsedUri) -or $parsedUri.Scheme -ne 'https') {
+        Write-Host "Winget lookup REFUSED: InstallerUrl for '$PackageId' $Version is not a valid HTTPS URL" -ForegroundColor Red
+        Write-Host "  URL: $Url" -ForegroundColor Red
+        return $null
+    }
+    $canonicalUrl = $parsedUri.AbsoluteUri
+
+    $allowed = $false
+    foreach ($prefix in $ValidPrefixes) {
+        if ($canonicalUrl.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) { $allowed = $true; break }
+    }
+    if (-not $allowed) {
+        Write-Host "Winget lookup REFUSED: InstallerUrl for '$PackageId' $Version is outside the allowed prefixes" -ForegroundColor Red
+        Write-Host "  URL (canonical): $canonicalUrl" -ForegroundColor Red
+        return $null
+    }
+
+    # The decoded leaf must be a plain file name: encoded separators or traversal tokens
+    # (%2F, %5C, %2E%2E) survive URI canonicalization inside a single segment, and letting
+    # them through would smuggle path components into Join-Path targets and the version cache
+    $filename = [System.Uri]::UnescapeDataString($parsedUri.Segments[-1])
+    if ([string]::IsNullOrWhiteSpace($filename) -or
+        $filename -in @('.', '..') -or
+        $filename -ne [System.IO.Path]::GetFileName($filename) -or
+        $filename.IndexOfAny([System.IO.Path]::GetInvalidFileNameChars()) -ge 0) {
+        Write-Host "Winget lookup REFUSED: InstallerUrl for '$PackageId' $Version does not end in a usable file name" -ForegroundColor Red
+        Write-Host "  Decoded leaf: $filename" -ForegroundColor Red
+        return $null
+    }
+
+    return @{ Url = $canonicalUrl; Filename = $filename }
 }
 
 # Resolves the latest version, download URL and SHA-256 of a package from the community
@@ -498,15 +751,8 @@ function Get-WingetInstallerInfo {
 
     # The allowlist is not optional: without it the manifest alone would decide where
     # installers come from. Fail closed - before spending any network calls - rather than
-    # letting a caller accidentally skip the check. A usable prefix must be an absolute
-    # https:// URL ending in '/', so a StartsWith match can never cross an authority
-    # boundary ("https://vendor.example" must not match "https://vendor.example.evil.com/").
-    $validPrefixes = @($AllowedUrlPrefixes | Where-Object {
-        if ([string]::IsNullOrWhiteSpace($_)) { return $false }
-        $prefixUri = $null
-        [System.Uri]::TryCreate($_, [System.UriKind]::Absolute, [ref]$prefixUri) -and
-            $prefixUri.Scheme -eq 'https' -and $_.EndsWith('/')
-    })
+    # letting a caller accidentally skip the check.
+    $validPrefixes = Select-WingetAllowedPrefix -AllowedUrlPrefixes $AllowedUrlPrefixes
     if ($validPrefixes.Count -eq 0) {
         Write-Host "Winget lookup REFUSED: no usable AllowedUrlPrefixes for '$PackageId' - the allowlist is mandatory and every prefix must be an https:// URL ending in '/'" -ForegroundColor Red
         return $null
@@ -516,114 +762,25 @@ function Get-WingetInstallerInfo {
     $letter = $PackageId.Substring(0, 1).ToLowerInvariant()
     $manifestRoot = "manifests/$letter/$idPath"
 
-    # Latest version = highest directory name that parses as [version]; tags like "Nightly" are skipped
-    try {
-        $listing = Invoke-RestMethod -Uri "https://api.github.com/repos/microsoft/winget-pkgs/contents/$manifestRoot" -ErrorAction Stop
-    }
-    catch {
-        Write-Host "Winget lookup FAILED: could not list versions for '$PackageId': $($_.Exception.Message)" -ForegroundColor Red
-        return $null
-    }
+    $latest = Get-WingetLatestVersion -PackageId $PackageId -ManifestRoot $manifestRoot
+    if (-not $latest) { return $null }
 
-    $versions = foreach ($item in $listing) {
-        if ($item.type -ne 'dir') { continue }
-        $parsed = $null
-        if ([version]::TryParse($item.name, [ref]$parsed)) {
-            [PSCustomObject]@{ Name = $item.name; Version = $parsed }
-        }
-    }
-    $latest = $versions | Sort-Object Version -Descending | Select-Object -First 1
-    if (-not $latest) {
-        Write-Host "Winget lookup FAILED: no parseable versions found for '$PackageId'" -ForegroundColor Red
-        return $null
-    }
+    $manifest = Get-WingetInstallerManifest -PackageId $PackageId -ManifestRoot $manifestRoot -Version $latest.Name
+    if (-not $manifest) { return $null }
 
-    try {
-        $yaml = Invoke-RestMethod -Uri "https://raw.githubusercontent.com/microsoft/winget-pkgs/master/$manifestRoot/$($latest.Name)/$PackageId.installer.yaml" -ErrorAction Stop
-    }
-    catch {
-        Write-Host "Winget lookup FAILED: could not fetch installer manifest for '$PackageId' $($latest.Name): $($_.Exception.Message)" -ForegroundColor Red
-        return $null
-    }
+    $entry = Select-WingetInstallerEntry -Manifest $manifest -PackageId $PackageId -Version $latest.Name -Architecture $Architecture -InstallerType $InstallerType
+    if (-not $entry) { return $null }
 
-    $manifest = ConvertFrom-WingetInstallerManifest -Yaml $yaml
-
-    # The manifest must describe the version whose directory it lives in - a disagreement
-    # means a raced listing or a manipulated manifest, and either way the bundle is not
-    # the "version + URL + hash" unit we claim to verify
-    $declaredVersion = $manifest.Defaults['PackageVersion']
-    if ($declaredVersion -and $declaredVersion -ne $latest.Name) {
-        Write-Host "Winget lookup FAILED: manifest in directory '$($latest.Name)' declares PackageVersion '$declaredVersion' for '$PackageId'" -ForegroundColor Red
-        return $null
-    }
-
-    $candidates = @($manifest.Installers | Where-Object {
-        $arch = if ($_.ContainsKey('Architecture')) { $_.Architecture } else { $manifest.Defaults['Architecture'] }
-        $type = if ($_.ContainsKey('InstallerType')) { $_.InstallerType } else { $manifest.Defaults['InstallerType'] }
-        ($arch -eq $Architecture) -and (-not $InstallerType -or $type -eq $InstallerType)
-    })
-
-    if ($candidates.Count -ne 1) {
-        Write-Host "Winget lookup FAILED: expected exactly 1 installer entry for '$PackageId' $($latest.Name) ($Architecture/$InstallerType), found $($candidates.Count)" -ForegroundColor Red
-        return $null
-    }
-
-    $url = $candidates[0]['InstallerUrl']
-    $sha256 = "$($candidates[0]['InstallerSha256'])".Trim()
-    if (-not $url -or -not $sha256) {
-        Write-Host "Winget lookup FAILED: installer entry for '$PackageId' $($latest.Name) is missing InstallerUrl or InstallerSha256" -ForegroundColor Red
-        return $null
-    }
-
-    # Downstream verification would reject a malformed pin anyway (fail closed), but
-    # refusing here avoids downloading an installer that can never verify
-    if ($sha256 -notmatch '^[0-9A-Fa-f]{64}$') {
-        Write-Host "Winget lookup FAILED: InstallerSha256 for '$PackageId' $($latest.Name) is not a 64-character hex hash" -ForegroundColor Red
-        return $null
-    }
-
-    # Canonicalize before the allowlist check and use the canonical form from here on:
-    # System.Uri compacts dot segments (escaped or not), so a raw-string prefix match on
-    # "https://host/allowed/../attacker/..." would pass while the request actually goes
-    # elsewhere. The canonical AbsoluteUri is what the HTTP client will really fetch.
-    $parsedUri = $null
-    if (-not [System.Uri]::TryCreate($url, [System.UriKind]::Absolute, [ref]$parsedUri) -or $parsedUri.Scheme -ne 'https') {
-        Write-Host "Winget lookup REFUSED: InstallerUrl for '$PackageId' $($latest.Name) is not a valid HTTPS URL" -ForegroundColor Red
-        Write-Host "  URL: $url" -ForegroundColor Red
-        return $null
-    }
-    $canonicalUrl = $parsedUri.AbsoluteUri
-
-    $allowed = $false
-    foreach ($prefix in $validPrefixes) {
-        if ($canonicalUrl.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) { $allowed = $true; break }
-    }
-    if (-not $allowed) {
-        Write-Host "Winget lookup REFUSED: InstallerUrl for '$PackageId' $($latest.Name) is outside the allowed prefixes" -ForegroundColor Red
-        Write-Host "  URL (canonical): $canonicalUrl" -ForegroundColor Red
-        return $null
-    }
-
-    # The decoded leaf must be a plain file name: encoded separators or traversal tokens
-    # (%2F, %5C, %2E%2E) survive URI canonicalization inside a single segment, and letting
-    # them through would smuggle path components into Join-Path targets and the version cache
-    $filename = [System.Uri]::UnescapeDataString($parsedUri.Segments[-1])
-    if ([string]::IsNullOrWhiteSpace($filename) -or
-        $filename -in @('.', '..') -or
-        $filename -ne [System.IO.Path]::GetFileName($filename) -or
-        $filename.IndexOfAny([System.IO.Path]::GetInvalidFileNameChars()) -ge 0) {
-        Write-Host "Winget lookup REFUSED: InstallerUrl for '$PackageId' $($latest.Name) does not end in a usable file name" -ForegroundColor Red
-        Write-Host "  Decoded leaf: $filename" -ForegroundColor Red
-        return $null
-    }
+    $download = Resolve-WingetInstallerUrl -Url $entry.Url -ValidPrefixes $validPrefixes -PackageId $PackageId -Version $latest.Name
+    if (-not $download) { return $null }
 
     Write-Host "Winget manifest resolved: $PackageId $($latest.Name) (SHA-256 pinned)" -ForegroundColor Green
 
     return [PSCustomObject]@{
         Version  = $latest.Name
-        Url      = $canonicalUrl
-        Sha256   = $sha256
-        Filename = $filename
+        Url      = $download.Url
+        Sha256   = $entry.Sha256
+        Filename = $download.Filename
     }
 }
 
@@ -843,6 +1000,46 @@ function Get-MsiAppConfig {
     }
 }
 
+# The detection rule of a file-based app: registry existence, registry version, or (the default)
+# file version.
+function New-FileAppDetectionRule {
+    param(
+        [Parameter(Mandatory=$true)] $AppConfig,
+        [Parameter(Mandatory=$true)] $CommonSettings,
+        [string]$Version,
+        [string]$Operator
+    )
+
+    if ($AppConfig.DetectionType -ne "Registry") {
+        # Default: file-based detection
+        return New-InteropFileDetectionRule `
+            -Path $AppConfig.DetectionPath `
+            -FileOrFolder $AppConfig.DetectionFile `
+            -Check32BitOn64System $CommonSettings.Check32BitOn64System `
+            -Operator $Operator `
+            -VersionValue $Version
+    }
+
+    if ($Operator -notin @('exists', 'doesNotExist', 'notExists')) {
+        return New-InteropRegistryVersionDetectionRule `
+            -KeyPath $AppConfig.DetectionPath `
+            -ValueName $AppConfig.DetectionValueName `
+            -Operator $Operator `
+            -VersionValue $Version `
+            -Check32BitOn64System $CommonSettings.Check32BitOn64System
+    }
+
+    $existenceParams = @{
+        KeyPath              = $AppConfig.DetectionPath
+        DetectionType        = if ($Operator -eq "notExists") { "doesNotExist" } else { $Operator }
+        Check32BitOn64System = $CommonSettings.Check32BitOn64System
+    }
+    if ($AppConfig.DetectionValueName) {
+        $existenceParams['ValueName'] = $AppConfig.DetectionValueName
+    }
+    return New-InteropRegistryExistenceDetectionRule @existenceParams
+}
+
 # Generic function to create File-based app configuration
 function Get-FileAppConfig {
     param(
@@ -850,67 +1047,34 @@ function Get-FileAppConfig {
         [string]$Version,
         [string]$SetupFile
     )
-    
+
     $appConfig = Get-AppConfiguration -AppName $AppName
     $commonSettings = Get-CommonSettings
-    
+
     # Use app-specific detection operator if specified, otherwise use common setting
     $detectionOperator = if ($appConfig.DetectionOperator) {
         $appConfig.DetectionOperator
     } else {
         $commonSettings.DetectionOperator
     }
-    
-    # Create detection rule based on detection type
-    if ($appConfig.DetectionType -eq "Registry") {
-        if ($detectionOperator -eq "exists" -or $detectionOperator -eq "doesNotExist" -or $detectionOperator -eq "notExists") {
-            if ($detectionOperator -eq "notExists") {
-                $detectionOperator = "doesNotExist"
-            }
-            $existenceParams = @{
-                KeyPath              = $appConfig.DetectionPath
-                DetectionType        = $detectionOperator
-                Check32BitOn64System = $commonSettings.Check32BitOn64System
-            }
-            if ($appConfig.DetectionValueName) {
-                $existenceParams['ValueName'] = $appConfig.DetectionValueName
-            }
-            $DetectionRule = New-InteropRegistryExistenceDetectionRule @existenceParams
-        }
-        else {
-            $DetectionRule = New-InteropRegistryVersionDetectionRule `
-                -KeyPath $appConfig.DetectionPath `
-                -ValueName $appConfig.DetectionValueName `
-                -Operator $detectionOperator `
-                -VersionValue $Version `
-                -Check32BitOn64System $commonSettings.Check32BitOn64System
-        }
-    }
-    else {
-        # Default: file-based detection
-        $DetectionRule = New-InteropFileDetectionRule `
-            -Path $appConfig.DetectionPath `
-            -FileOrFolder $appConfig.DetectionFile `
-            -Check32BitOn64System $commonSettings.Check32BitOn64System `
-            -Operator $detectionOperator `
-            -VersionValue $Version
-    }
-    
+
+    $DetectionRule = New-FileAppDetectionRule -AppConfig $appConfig -CommonSettings $commonSettings -Version $Version -Operator $detectionOperator
+
     $RequirementRule = New-InteropRequirementRule `
         -Architecture $commonSettings.Architecture `
         -MinimumSupportedOperatingSystem $commonSettings.MinimumOS
-    
+
     # Extract major version for display name (e.g., "143" from "143.0.4")
     $majorVersion = if ($Version -match '^(\d+)') { $matches[1] } else { $Version }
-    
+
     # Format display name with major version only, description without version
     $DisplayName = $appConfig.DisplayNameTemplate -f $majorVersion
     $Description = $appConfig.Description
-    
+
     # Format commands - {0} = setup filename, {1} = app version
     $InstallCommand = $appConfig.InstallCommandTemplate -f $SetupFile, $Version
     $UninstallCommand = $appConfig.UninstallCommandTemplate -f $SetupFile, $Version
-    
+
     return @{
         DisplayName = $DisplayName
         Description = $Description

--- a/TenantConfig.ps1
+++ b/TenantConfig.ps1
@@ -358,58 +358,31 @@ function Test-IntuneCredentials {
 
 #region Public Functions
 
-function Add-IntuneTenant {
-    <#
-    .SYNOPSIS
-    Adds a new tenant configuration with encrypted client secret
-    
-    .DESCRIPTION
-    Guides you through Azure AD app registration setup, then stores the tenant
-    configuration with an AES-256-GCM encrypted client secret.
-    
-    .PARAMETER Name
-    A friendly name for the tenant (e.g., "School", "District")
-    
-    .PARAMETER TenantId
-    The Azure AD Directory (tenant) ID
-    
-    .PARAMETER ClientId
-    The Application (client) ID from the app registration
-    
-    .EXAMPLE
-    Add-IntuneTenant -Name "School"
-    
-    .EXAMPLE
-    Add-IntuneTenant -Name "District" -TenantId "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -ClientId "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy"
-    #>
-    [CmdletBinding()]
+# The plaintext behind a SecureString. The unmanaged BSTR is always zeroed and freed, whatever
+# happens in between - the only reason this dance exists.
+function ConvertFrom-SecureStringPlain {
     param(
         [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [string]$Name,
-        
-        [Parameter(Mandatory = $false)]
-        [string]$TenantId,
-        
-        [Parameter(Mandatory = $false)]
-        [string]$ClientId
+        [System.Security.SecureString]$SecureString
     )
-    
-    Write-Host ""
-    Write-Host "========================================" -ForegroundColor Cyan
-    Write-Host "  Add Intune Tenant: $Name" -ForegroundColor Cyan
-    Write-Host "========================================" -ForegroundColor Cyan
-    Write-Host ""
-    
-    # Check if tenant already exists
-    $config = Read-TenantConfig
-    if ($config.tenants.PSObject.Properties.Name -contains $Name) {
-        Write-Host "A tenant with name '$Name' already exists." -ForegroundColor Yellow
-        Write-Host "To update it, first remove it with: Remove-IntuneTenant -Name '$Name'" -ForegroundColor Yellow
-        return
+
+    $ptr = [System.IntPtr]::Zero
+    try {
+        $ptr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString)
+        return [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ptr)
     }
-    
-    # Display setup instructions if TenantId not provided
+    finally {
+        if ($ptr -ne [System.IntPtr]::Zero) {
+            [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ptr)
+        }
+    }
+}
+
+# A validated Directory (tenant) ID: the one passed in, or one read from the console after the
+# setup instructions. $null when it is missing or not a GUID (the caller aborts).
+function Read-IntuneTenantIdValue {
+    param([string]$TenantId)
+
     if (-not $TenantId) {
         Write-Host "STEP 1: Find your Tenant ID" -ForegroundColor Green
         Write-Host "-------------------------------------------------------------------" -ForegroundColor Gray
@@ -417,21 +390,27 @@ function Add-IntuneTenant {
         Write-Host "2. Navigate to: Azure Active Directory (or Microsoft Entra ID)"
         Write-Host "3. On the Overview page, copy the 'Tenant ID' (Directory ID)"
         Write-Host ""
-        
+
         $TenantId = Read-Host "Enter Tenant ID (GUID)"
         if ([string]::IsNullOrWhiteSpace($TenantId)) {
             Write-Host "Tenant ID is required. Aborting." -ForegroundColor Red
-            return
+            return $null
         }
     }
-    
-    # Validate TenantId format
+
     if ($TenantId -notmatch '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$') {
         Write-Host "Invalid Tenant ID format. Expected a GUID." -ForegroundColor Red
-        return
+        return $null
     }
-    
-    # Display app registration instructions if ClientId not provided
+
+    return $TenantId
+}
+
+# A validated Application (client) ID: the one passed in, or one read from the console after the
+# app-registration instructions. $null when it is missing or not a GUID (the caller aborts).
+function Read-IntuneClientIdValue {
+    param([string]$ClientId)
+
     if (-not $ClientId) {
         Write-Host ""
         Write-Host "STEP 2: Create an App Registration" -ForegroundColor Green
@@ -445,20 +424,169 @@ function Add-IntuneTenant {
         Write-Host "4. Click 'Register'"
         Write-Host "5. Copy the 'Application (client) ID' from the Overview page"
         Write-Host ""
-        
+
         $ClientId = Read-Host "Enter Application (Client) ID (GUID)"
         if ([string]::IsNullOrWhiteSpace($ClientId)) {
             Write-Host "Client ID is required. Aborting." -ForegroundColor Red
-            return
+            return $null
         }
     }
-    
-    # Validate ClientId format
+
     if ($ClientId -notmatch '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$') {
         Write-Host "Invalid Client ID format. Expected a GUID." -ForegroundColor Red
+        return $null
+    }
+
+    return $ClientId
+}
+
+# $true when the password decrypts an already stored tenant - the check that keeps a config file
+# from ending up with entries under two different passwords. A config without tenants passes.
+function Test-TenantMasterKey {
+    param(
+        [Parameter(Mandatory = $true)] $Config,
+        [Parameter(Mandatory = $true)] [string]$MasterKey
+    )
+
+    $existingTenantNames = @($Config.tenants.PSObject.Properties.Name)
+    if ($existingTenantNames.Count -eq 0) {
+        return $true
+    }
+
+    $testTenantName = $existingTenantNames | Select-Object -First 1
+    $testTenant = $Config.tenants.$testTenantName
+    $testDecrypt = Unprotect-Secret -EncryptedBase64 $testTenant.encryptedSecret -Password $MasterKey
+
+    if ($null -eq $testDecrypt) {
+        Write-Host "Incorrect encryption password (could not decrypt existing tenant '$testTenantName')." -ForegroundColor Red
+        Write-Host "Aborting to prevent mixing passwords in the config file." -ForegroundColor Yellow
+        return $false
+    }
+
+    Write-Host "Password verified against existing config." -ForegroundColor Gray
+    return $true
+}
+
+# The encryption password to store the new tenant under: the one cached for this session, or one
+# read from the console - confirmed for a new config file, validated against an existing entry
+# otherwise. Caches it for the session. $null when it is missing, mistyped or wrong.
+function Get-TenantMasterKeyForWrite {
+    param([Parameter(Mandatory = $true)] $Config)
+
+    $masterKey = Get-CachedMasterKey
+    if ($masterKey) {
+        Write-Host "Using cached encryption password from this session." -ForegroundColor Gray
+        return $masterKey
+    }
+
+    Write-Host "STEP 5: Set Encryption Password" -ForegroundColor Green
+    Write-Host "-------------------------------------------------------------------" -ForegroundColor Gray
+    Write-Host "This password encrypts your client secrets in the config file."
+    Write-Host "You need to enter it once per PowerShell session."
+    Write-Host ""
+
+    $masterKey = ConvertFrom-SecureStringPlain -SecureString (Read-Host "Enter encryption password" -AsSecureString)
+    if ([string]::IsNullOrWhiteSpace($masterKey)) {
+        Write-Host "Encryption password is required. Aborting." -ForegroundColor Red
+        return $null
+    }
+
+    # For new config: confirm password
+    # For existing config: validate by decrypting an existing entry
+    if (-not (Test-Path $script:ConfigFilePath)) {
+        $masterKeyConfirm = ConvertFrom-SecureStringPlain -SecureString (Read-Host "Confirm encryption password" -AsSecureString)
+        if ($masterKey -ne $masterKeyConfirm) {
+            Write-Host "Passwords do not match. Aborting." -ForegroundColor Red
+            return $null
+        }
+    }
+    elseif (-not (Test-TenantMasterKey -Config $Config -MasterKey $masterKey)) {
+        return $null
+    }
+
+    # Cache the master key for this session
+    Set-CachedMasterKey -Password $masterKey
+    return $masterKey
+}
+
+# The client secret of the new app registration, read from the console after the instructions.
+# $null when nothing was entered (the caller aborts).
+function Read-IntuneClientSecretValue {
+    Write-Host "STEP 4: Create a Client Secret" -ForegroundColor Green
+    Write-Host "-------------------------------------------------------------------" -ForegroundColor Gray
+    Write-Host "1. In your app registration, go to: Certificates and secrets"
+    Write-Host "2. Click '+ New client secret'"
+    Write-Host "3. Set description (e.g., 'IntuneDeploymentKey') and expiration"
+    Write-Host "4. Click 'Add'"
+    Write-Host "5. IMPORTANT: Copy the 'Value' immediately (it will not be shown again!)"
+    Write-Host ""
+
+    $clientSecret = ConvertFrom-SecureStringPlain -SecureString (Read-Host "Enter Client Secret Value" -AsSecureString)
+    if ([string]::IsNullOrWhiteSpace($clientSecret)) {
+        Write-Host "Client Secret is required. Aborting." -ForegroundColor Red
+        return $null
+    }
+
+    return $clientSecret
+}
+
+function Add-IntuneTenant {
+    <#
+    .SYNOPSIS
+    Adds a new tenant configuration with encrypted client secret
+
+    .DESCRIPTION
+    Guides you through Azure AD app registration setup, then stores the tenant
+    configuration with an AES-256-GCM encrypted client secret.
+
+    .PARAMETER Name
+    A friendly name for the tenant (e.g., "School", "District")
+
+    .PARAMETER TenantId
+    The Azure AD Directory (tenant) ID
+
+    .PARAMETER ClientId
+    The Application (client) ID from the app registration
+
+    .EXAMPLE
+    Add-IntuneTenant -Name "School"
+
+    .EXAMPLE
+    Add-IntuneTenant -Name "District" -TenantId "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" -ClientId "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy"
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [Parameter(Mandatory = $false)]
+        [string]$TenantId,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ClientId
+    )
+
+    Write-Host ""
+    Write-Host "========================================" -ForegroundColor Cyan
+    Write-Host "  Add Intune Tenant: $Name" -ForegroundColor Cyan
+    Write-Host "========================================" -ForegroundColor Cyan
+    Write-Host ""
+
+    # Check if tenant already exists
+    $config = Read-TenantConfig
+    if ($config.tenants.PSObject.Properties.Name -contains $Name) {
+        Write-Host "A tenant with name '$Name' already exists." -ForegroundColor Yellow
+        Write-Host "To update it, first remove it with: Remove-IntuneTenant -Name '$Name'" -ForegroundColor Yellow
         return
     }
-    
+
+    $TenantId = Read-IntuneTenantIdValue -TenantId $TenantId
+    if (-not $TenantId) { return }
+
+    $ClientId = Read-IntuneClientIdValue -ClientId $ClientId
+    if (-not $ClientId) { return }
+
     # Instructions for API permissions
     Write-Host ""
     Write-Host "STEP 3: Configure API Permissions" -ForegroundColor Green
@@ -472,40 +600,16 @@ function Add-IntuneTenant {
     Write-Host "4. Click 'Grant admin consent for [Your Organization]'"
     Write-Host "5. Verify all permissions show green checkmarks"
     Write-Host ""
-    
-    # Instructions for client secret
-    Write-Host "STEP 4: Create a Client Secret" -ForegroundColor Green
-    Write-Host "-------------------------------------------------------------------" -ForegroundColor Gray
-    Write-Host "1. In your app registration, go to: Certificates and secrets"
-    Write-Host "2. Click '+ New client secret'"
-    Write-Host "3. Set description (e.g., 'IntuneDeploymentKey') and expiration"
-    Write-Host "4. Click 'Add'"
-    Write-Host "5. IMPORTANT: Copy the 'Value' immediately (it will not be shown again!)"
-    Write-Host ""
-    
-    $secureSecret = Read-Host "Enter Client Secret Value" -AsSecureString
-    $clientSecretPtr = [System.IntPtr]::Zero
-    try {
-        $clientSecretPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureSecret)
-        $clientSecret = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($clientSecretPtr)
-    }
-    finally {
-        if ($clientSecretPtr -ne [System.IntPtr]::Zero) {
-            [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($clientSecretPtr)
-        }
-    }
-    
-    if ([string]::IsNullOrWhiteSpace($clientSecret)) {
-        Write-Host "Client Secret is required. Aborting." -ForegroundColor Red
-        return
-    }
-    
+
+    $clientSecret = Read-IntuneClientSecretValue
+    if (-not $clientSecret) { return }
+
     # Test credentials before storing
     Write-Host ""
     Write-Host "Testing credentials..." -ForegroundColor Cyan
-    
+
     $testResult = Test-IntuneCredentials -TenantId $TenantId -ClientId $ClientId -ClientSecret $clientSecret
-    
+
     if (-not $testResult) {
         Write-Host ""
         Write-Host "Credential test FAILED. Please verify:" -ForegroundColor Red
@@ -517,104 +621,36 @@ function Add-IntuneTenant {
         Write-Host "Tenant was NOT saved." -ForegroundColor Red
         return
     }
-    
+
     Write-Host "Credential test PASSED!" -ForegroundColor Green
     Write-Host ""
-    
-    # Get or prompt for master password
-    $masterKey = Get-CachedMasterKey
-    if (-not $masterKey) {
-        Write-Host "STEP 5: Set Encryption Password" -ForegroundColor Green
-        Write-Host "-------------------------------------------------------------------" -ForegroundColor Gray
-        Write-Host "This password encrypts your client secrets in the config file."
-        Write-Host "You need to enter it once per PowerShell session."
-        Write-Host ""
-        
-        $securePassword = Read-Host "Enter encryption password" -AsSecureString
-        $masterKeyPtr = [System.IntPtr]::Zero
-        try {
-            $masterKeyPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($securePassword)
-            $masterKey = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($masterKeyPtr)
-        }
-        finally {
-            if ($masterKeyPtr -ne [System.IntPtr]::Zero) {
-                [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($masterKeyPtr)
-            }
-        }
-        
-        if ([string]::IsNullOrWhiteSpace($masterKey)) {
-            Write-Host "Encryption password is required. Aborting." -ForegroundColor Red
-            return
-        }
-        
-        # For new config: confirm password
-        # For existing config: validate by decrypting an existing entry
-        if (-not (Test-Path $script:ConfigFilePath)) {
-            # New config - confirm password
-            $securePasswordConfirm = Read-Host "Confirm encryption password" -AsSecureString
-            $confirmPtr = [System.IntPtr]::Zero
-            try {
-                $confirmPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($securePasswordConfirm)
-                $masterKeyConfirm = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($confirmPtr)
-            }
-            finally {
-                if ($confirmPtr -ne [System.IntPtr]::Zero) {
-                    [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($confirmPtr)
-                }
-            }
-            
-            if ($masterKey -ne $masterKeyConfirm) {
-                Write-Host "Passwords do not match. Aborting." -ForegroundColor Red
-                return
-            }
-        }
-        else {
-            # Existing config - validate password by decrypting an existing entry
-            $existingTenantNames = $config.tenants.PSObject.Properties.Name
-            if ($existingTenantNames.Count -gt 0) {
-                $testTenantName = $existingTenantNames | Select-Object -First 1
-                $testTenant = $config.tenants.$testTenantName
-                $testDecrypt = Unprotect-Secret -EncryptedBase64 $testTenant.encryptedSecret -Password $masterKey
-                
-                if ($null -eq $testDecrypt) {
-                    Write-Host "Incorrect encryption password (could not decrypt existing tenant '$testTenantName')." -ForegroundColor Red
-                    Write-Host "Aborting to prevent mixing passwords in the config file." -ForegroundColor Yellow
-                    return
-                }
-                Write-Host "Password verified against existing config." -ForegroundColor Gray
-            }
-        }
-        
-        # Cache the master key for this session
-        Set-CachedMasterKey -Password $masterKey
-    }
-    else {
-        Write-Host "Using cached encryption password from this session." -ForegroundColor Gray
-    }
-    
+
+    $masterKey = Get-TenantMasterKeyForWrite -Config $config
+    if (-not $masterKey) { return }
+
     # Encrypt the client secret
     $encryptedSecret = Protect-Secret -PlainText $clientSecret -Password $masterKey
-    
+
     # Add tenant to config
     $tenantConfig = [PSCustomObject]@{
         tenantId        = $TenantId
         clientId        = $ClientId
         encryptedSecret = $encryptedSecret
     }
-    
+
     # Handle empty tenants object
     if ($null -eq $config.tenants -or $config.tenants -isnot [PSCustomObject]) {
         $config.tenants = [PSCustomObject]@{}
     }
-    
+
     $config.tenants | Add-Member -MemberType NoteProperty -Name $Name -Value $tenantConfig -Force
-    
+
     # Save config
     Write-TenantConfig -Config $config
-    
+
     # Cache the decrypted secret for this session
     Set-CachedTenantSecret -TenantName $Name -Secret $clientSecret
-    
+
     Write-Host ""
     Write-Host "========================================" -ForegroundColor Green
     Write-Host "  Tenant '$Name' added successfully!" -ForegroundColor Green
@@ -628,21 +664,63 @@ function Add-IntuneTenant {
     Write-Host ""
 }
 
+# The tenant's decrypted client secret, prompting for the encryption password when none is cached
+# and retrying once after a wrong one. Caches password and secret for the session on success;
+# $null when the secret stays undecryptable.
+function Unprotect-TenantSecret {
+    param(
+        [Parameter(Mandatory = $true)] $Tenant,
+        [Parameter(Mandatory = $true)] [string]$TenantName
+    )
+
+    for ($attempt = 1; $attempt -le 2; $attempt++) {
+        $masterKey = Get-CachedMasterKey
+        if (-not $masterKey) {
+            Write-Host "Enter encryption password for tenant config:" -ForegroundColor Cyan
+            $masterKey = ConvertFrom-SecureStringPlain -SecureString (Read-Host "Password" -AsSecureString)
+
+            if ([string]::IsNullOrWhiteSpace($masterKey)) {
+                Write-Host "Password is required." -ForegroundColor Red
+                return $null
+            }
+        }
+
+        $clientSecret = Unprotect-Secret -EncryptedBase64 $Tenant.encryptedSecret -Password $masterKey
+        if ($null -ne $clientSecret) {
+            # Cache for this session
+            Set-CachedMasterKey -Password $masterKey
+            Set-CachedTenantSecret -TenantName $TenantName -Secret $clientSecret
+            return $clientSecret
+        }
+
+        # Decryption failed: clear cached master key and retry once
+        Write-Host "Failed to decrypt client secret. Wrong password?" -ForegroundColor Red
+        $global:__IntuneCachedMasterKey = $null
+
+        if ($attempt -lt 2) {
+            Write-Host "Cleared cached encryption password. Please try again." -ForegroundColor Yellow
+        }
+    }
+
+    # All attempts exhausted
+    return $null
+}
+
 function Get-IntuneTenant {
     <#
     .SYNOPSIS
     Retrieves tenant credentials for deployment
-    
+
     .DESCRIPTION
-    Gets the tenant configuration, decrypts the client secret (prompting for 
+    Gets the tenant configuration, decrypts the client secret (prompting for
     password if not cached), and returns a credential object.
-    
+
     .PARAMETER Name
     The friendly name of the tenant to retrieve
-    
+
     .OUTPUTS
     PSCustomObject with TenantId, ClientId, and ClientSecret properties
-    
+
     .EXAMPLE
     $creds = Get-IntuneTenant -Name "School"
     .\Deploy-ToIntune.ps1 -TenantId $creds.TenantId -ClientId $creds.ClientId -ClientSecret $creds.ClientSecret
@@ -653,17 +731,17 @@ function Get-IntuneTenant {
         [ValidateNotNullOrEmpty()]
         [string]$Name
     )
-    
+
     # Check if config file exists
     if (-not (Test-Path $script:ConfigFilePath)) {
         Write-Host "No tenant configuration found." -ForegroundColor Red
         Write-Host "Run 'Add-IntuneTenant -Name `"$Name`"' to set up a tenant." -ForegroundColor Yellow
         return $null
     }
-    
+
     # Read config
     $config = Read-TenantConfig
-    
+
     # Check if tenant exists
     if ($config.tenants.PSObject.Properties.Name -notcontains $Name) {
         Write-Host "Tenant '$Name' not found in configuration." -ForegroundColor Red
@@ -672,68 +750,23 @@ function Get-IntuneTenant {
         Get-AllIntuneTenants
         return $null
     }
-    
+
     $tenant = $config.tenants.$Name
-    
-    # Check session cache first
-    $cachedSecret = Get-CachedTenantSecret -TenantName $Name
-    if ($cachedSecret) {
-        return [PSCustomObject]@{
-            TenantId     = $tenant.tenantId
-            ClientId     = $tenant.clientId
-            ClientSecret = $cachedSecret
-        }
+
+    # Check session cache first, then decrypt (prompting for the password)
+    $clientSecret = Get-CachedTenantSecret -TenantName $Name
+    if (-not $clientSecret) {
+        $clientSecret = Unprotect-TenantSecret -Tenant $tenant -TenantName $Name
     }
-    
-    # Get or prompt for master password, with retry on decryption failure
-    for ($attempt = 1; $attempt -le 2; $attempt++) {
-        $masterKey = Get-CachedMasterKey
-        if (-not $masterKey) {
-            Write-Host "Enter encryption password for tenant config:" -ForegroundColor Cyan
-            $securePassword = Read-Host "Password" -AsSecureString
-            $passwordPtr = [System.IntPtr]::Zero
-            try {
-                $passwordPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($securePassword)
-                $masterKey = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($passwordPtr)
-            }
-            finally {
-                if ($passwordPtr -ne [System.IntPtr]::Zero) {
-                    [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($passwordPtr)
-                }
-            }
-            
-            if ([string]::IsNullOrWhiteSpace($masterKey)) {
-                Write-Host "Password is required." -ForegroundColor Red
-                return $null
-            }
-        }
-        
-        # Decrypt the secret
-        $clientSecret = Unprotect-Secret -EncryptedBase64 $tenant.encryptedSecret -Password $masterKey
-        
-        if ($null -ne $clientSecret) {
-            # Cache for this session
-            Set-CachedMasterKey -Password $masterKey
-            Set-CachedTenantSecret -TenantName $Name -Secret $clientSecret
-            
-            return [PSCustomObject]@{
-                TenantId     = $tenant.tenantId
-                ClientId     = $tenant.clientId
-                ClientSecret = $clientSecret
-            }
-        }
-        
-        # Decryption failed: clear cached master key and retry once
-        Write-Host "Failed to decrypt client secret. Wrong password?" -ForegroundColor Red
-        $global:__IntuneCachedMasterKey = $null
-        
-        if ($attempt -lt 2) {
-            Write-Host "Cleared cached encryption password. Please try again." -ForegroundColor Yellow
-        }
+    if (-not $clientSecret) {
+        return $null
     }
-    
-    # All attempts exhausted
-    return $null
+
+    return [PSCustomObject]@{
+        TenantId     = $tenant.tenantId
+        ClientId     = $tenant.clientId
+        ClientSecret = $clientSecret
+    }
 }
 
 function Get-AllIntuneTenants {


### PR DESCRIPTION
Clears all **26 open SonarCloud issues** on `main`: 21 `S3776` cognitive-complexity findings, 4 empty `catch` blocks (`S8657`) and one pipeline-indentation finding (`S8621`).

**No behaviour change.** Every function keeps its exact output, call sequence and failure modes; this is structure only, so there is no version bump (like #30).

## The complexity work

One pattern throughout: every rule or step becomes a named function carrying the comment that states the rule, and the caller is left as a flat sequence of those calls.

| Function | Before | After | Split into |
| --- | ---: | ---: | --- |
| `Publish-App` | 112 | 8 | version state, headroom pre-flight, upload, supersedence, dependency resolve/auto-deploy |
| `Format-AppInventoryMarkdown` | 57 | 1 | one builder per report section |
| `Set-AppAssignment` | 52 | 6 | per-target assigners + `Resolve-EntraGroup` |
| `ConvertTo-AppInventoryRecord` | 49 | 2 | one converter per record field group |
| `Get-AppInventoryAnalysis` | 46 | 7 | anomaly rules split by what they are about (data / portal / auto-update) |
| `Get-AppCleanupPlan` | 43 | 1 | skip-reason chain, entry builder, per-family plan |
| `Read-IntuneAppInventory` | 39 | 5 | list, ensure-ids, group names, install summary, per-app reads |
| `Get-AppRetentionPlan` | 36 | 3 | ranks, supersession, entry builders |
| `Add-IntuneTenant` | 36 | 7 | prompt/validate per field, master-key resolution |

Plus `Get-WingetInstallerInfo` (31), `Get-LatestVersionInfo` (28), `ConvertFrom-WingetInstallerManifest` (27), `Get-InstallerVersion` (26), `Invoke-IntuneAppCleanup` (23), `Invoke-InteropAzureBlobUpload` (22), `Test-DownloadedFileIntegrity` (21), `Get-AppConfigPolicyViolation` (21), `Publish-InteropWin32App` (20), `Import-AppVersionCache` (18), `Get-FileAppConfig` (16) and `Get-IntuneTenant` (16).

## The other five findings

- Empty `catch` blocks in `SharedFunctions.ps1` (COM release, ×2), `IntuneInterop.ps1` (non-JSON Graph error body) and `Deploy-ToIntune.ps1` (dependency icon) now say why they swallow and log it. The icon one warns instead of failing silently.
- The families table in `Get-IntuneAppInventory.ps1` is now one pipeline stage per line.

## How this was verified

Most of the refactored code has no unit coverage, so the Pester suite alone was not enough:

- **Pester**: 267 passed, 0 failed, re-run after every file.
- **An AST cognitive-complexity checker** implementing Sonar's rule: run against the parent commit it reports exactly the same 21 functions with the same scores SonarCloud gave (only `Publish-InteropWin32App` differs, 19 vs 20). Run against this branch: **0 of 199 functions over 15**. It also caught two functions left at 17 and 15, which were trimmed.
- **Differential harnesses**, old against new, comparing console output and every interop call:
  - deploy: 20 scenarios (assignment paths, upload-failure recovery, supersedence failure, graph limit, dependency auto-deploy) — identical
  - download resolvers: 18 scenarios across every version source and fallback — identical
  - interop publish/upload: 6 scenarios including chunk and block-list retries — identical
  - inventory: records, analysis, and both markdown variants — identical
  - tenant add/get: 12 scenarios (wrong-password retry, confirmation mismatch, mixed-password refusal) — identical
- Both CI gates pass locally (parse check, `IntuneWin32App` boundary tripwire).

## Two things deliberately preserved

- Helpers returning arrays use `,$array`, so an empty result stays an empty array instead of collapsing to `$null` — without it, "no assignments read" silently became "assignments unavailable" (caught by the suite mid-refactor).
- `SupersedenceGraphNodes` keeps the double `Measure-Object` produces, so inventory JSON still reads `2.0` rather than `2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
